### PR TITLE
chore(btcslasher): uses semaphore to limit btc node requests

### DIFF
--- a/btcstaking-tracker/btcslasher/bootstrapping_test.go
+++ b/btcstaking-tracker/btcslasher/bootstrapping_test.go
@@ -69,6 +69,7 @@ func FuzzSlasher_Bootstrapping(f *testing.F) {
 			commonCfg.RetrySleepTime,
 			commonCfg.MaxRetrySleepTime,
 			commonCfg.MaxRetryTimes,
+			config.MaxSlashingConcurrency,
 			slashedFPSKChan,
 			metrics.NewBTCStakingTrackerMetrics().SlasherMetrics,
 		)

--- a/btcstaking-tracker/btcslasher/slasher.go
+++ b/btcstaking-tracker/btcslasher/slasher.go
@@ -267,7 +267,7 @@ func (bs *BTCSlasher) SlashFinalityProvider(extractedFpBTCSK *btcec.PrivateKey) 
 		bs.wg.Add(1)
 		go func(d *bstypes.BTCDelegationResponse) {
 			defer bs.wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), semaphoreTimeout)
+			ctx, cancel := bs.quitContext()
 			defer cancel()
 
 			// Acquire the semaphore before interacting with the BTC node

--- a/btcstaking-tracker/btcslasher/slasher_test.go
+++ b/btcstaking-tracker/btcslasher/slasher_test.go
@@ -79,6 +79,7 @@ func FuzzSlasher(f *testing.F) {
 			commonCfg.RetrySleepTime,
 			commonCfg.MaxRetrySleepTime,
 			commonCfg.MaxRetryTimes,
+			config.MaxSlashingConcurrency,
 			slashedFPSKChan,
 			metrics.NewBTCStakingTrackerMetrics().SlasherMetrics,
 		)

--- a/btcstaking-tracker/tracker.go
+++ b/btcstaking-tracker/tracker.go
@@ -88,6 +88,7 @@ func NewBTCSTakingTracker(
 		commonCfg.RetrySleepTime,
 		commonCfg.MaxRetrySleepTime,
 		commonCfg.MaxRetryTimes,
+		cfg.MaxSlashingConcurrency,
 		slashedFPSKChan,
 		metrics.SlasherMetrics,
 	)


### PR DESCRIPTION
Limits the number of concurrent requests managed by a semaphore

[References issue](https://github.com/babylonchain/vigilante-private/issues/48)