### PR TITLE
chore(e2e): run e2e tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 6 --tags=e2e
+	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 12 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 6 --tags=e2e
+	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 10 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 10 --tags=e2e
+	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 6 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -race -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e
+	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 10 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/e2etest/atomicslasher_e2e_test.go
+++ b/e2etest/atomicslasher_e2e_test.go
@@ -140,8 +140,7 @@ func TestAtomicSlasher(t *testing.T) {
 // TestAtomicSlasher_Unbonding tests the atomic slasher's handling of unbonding BTC delegations,
 // including the creation and detection of unbonding slashing transactions.
 func TestAtomicSlasher_Unbonding(t *testing.T) {
-	t.Skip()
-	//t.Parallel()
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 

--- a/e2etest/atomicslasher_e2e_test.go
+++ b/e2etest/atomicslasher_e2e_test.go
@@ -22,6 +22,7 @@ import (
 // TestAtomicSlasher verifies the behavior of the atomic slasher by setting up delegations,
 // sending slashing transactions, and ensuring that slashing is detected and executed correctly.
 func TestAtomicSlasher(t *testing.T) {
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 
@@ -139,6 +140,8 @@ func TestAtomicSlasher(t *testing.T) {
 // TestAtomicSlasher_Unbonding tests the atomic slasher's handling of unbonding BTC delegations,
 // including the creation and detection of unbonding slashing transactions.
 func TestAtomicSlasher_Unbonding(t *testing.T) {
+	t.Skip()
+	//t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 

--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -153,12 +153,7 @@ func (m *Manager) RunBitcoindResource(
 				fmt.Sprintf("%s/:/data/.bitcoin", bitcoindCfgPath),
 			},
 			ExposedPorts: []string{
-				"8332",
-				"8333",
-				"28332",
-				"28333",
-				"18443",
-				"18444",
+				"18443/tcp",
 			},
 			Cmd: []string{
 				"-regtest",
@@ -173,13 +168,9 @@ func (m *Manager) RunBitcoindResource(
 		},
 		func(config *docker.HostConfig) {
 			config.PortBindings = map[docker.Port][]docker.PortBinding{
-				"8332/tcp":  {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"8333/tcp":  {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"28332/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"28333/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"18443/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"18444/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
+				"18443/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}}, // only expose what we need
 			}
+			config.PublishAllPorts = false // because in dockerfile they already expose them
 		},
 		noRestart,
 	)
@@ -222,20 +213,14 @@ func (m *Manager) RunBabylondResource(
 				fmt.Sprintf("%s/:/home/", mounthPath),
 			},
 			ExposedPorts: []string{
-				"1317",
-				"2345",
-				"9090",
-				"26656",
-				"26657",
+				"9090/tcp", // only expose what we need
+				"26657/tcp",
 			},
 			Cmd: cmd,
 		},
 		func(config *docker.HostConfig) {
 			config.PortBindings = map[docker.Port][]docker.PortBinding{
-				"1317/tcp":  {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"2345/tcp":  {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
 				"9090/tcp":  {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
-				"26656/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
 				"26657/tcp": {{HostIP: "", HostPort: strconv.Itoa(randomAvailablePort(t))}},
 			}
 		},

--- a/e2etest/monitor_e2e_test.go
+++ b/e2etest/monitor_e2e_test.go
@@ -25,6 +25,7 @@ import (
 
 // TestMonitorBootstrap - validates that after a restart monitor bootstraps from DB
 func TestMonitorBootstrap(t *testing.T) {
+	t.Parallel()
 	numMatureOutputs := uint32(150)
 
 	tm := StartManager(t, numMatureOutputs, 2)

--- a/e2etest/reporter_e2e_test.go
+++ b/e2etest/reporter_e2e_test.go
@@ -54,6 +54,7 @@ func (tm *TestManager) GenerateAndSubmitBlockNBlockStartingFromDepth(t *testing.
 }
 
 func TestReporter_BoostrapUnderFrequentBTCHeaders(t *testing.T) {
+	t.Parallel()
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)
 
@@ -117,6 +118,7 @@ func TestReporter_BoostrapUnderFrequentBTCHeaders(t *testing.T) {
 }
 
 func TestRelayHeadersAndHandleRollbacks(t *testing.T) {
+	t.Parallel()
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)
 
@@ -168,6 +170,7 @@ func TestRelayHeadersAndHandleRollbacks(t *testing.T) {
 }
 
 func TestHandleReorgAfterRestart(t *testing.T) {
+	t.Parallel()
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)
 

--- a/e2etest/slasher_e2e_test.go
+++ b/e2etest/slasher_e2e_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestSlasher_GracefulShutdown(t *testing.T) {
+	t.Parallel()
 	numMatureOutputs := uint32(300)
 
 	tm := StartManager(t, numMatureOutputs, defaultEpochInterval)
@@ -65,6 +66,7 @@ func TestSlasher_GracefulShutdown(t *testing.T) {
 }
 
 func TestSlasher_Slasher(t *testing.T) {
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 
@@ -133,6 +135,7 @@ func TestSlasher_Slasher(t *testing.T) {
 }
 
 func TestSlasher_SlashingUnbonding(t *testing.T) {
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 
@@ -219,6 +222,7 @@ func TestSlasher_SlashingUnbonding(t *testing.T) {
 }
 
 func TestSlasher_Bootstrapping(t *testing.T) {
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 

--- a/e2etest/submitter_e2e_test.go
+++ b/e2etest/submitter_e2e_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestSubmitterSubmission(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	numMatureOutputs := uint32(300)
 
@@ -97,6 +98,7 @@ func TestSubmitterSubmission(t *testing.T) {
 }
 
 func TestSubmitterSubmissionReplace(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	numMatureOutputs := uint32(300)
 

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -96,7 +96,6 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	cfg := defaultVigilanteConfig()
 
 	cfg.BTC.Endpoint = fmt.Sprintf("127.0.0.1:%s", bitcoind.GetPort("18443/tcp"))
-	cfg.BTC.ZmqSeqEndpoint = fmt.Sprintf("tcp:// 127.0.0.1:%s", bitcoind.GetPort("28333/tcp"))
 
 	testRpcClient, err := rpcclient.New(&rpcclient.ConnConfig{
 		Host:                 cfg.BTC.Endpoint,

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestUnbondingWatcher(t *testing.T) {
+	t.Parallel()
 	// segwit is activated at height 300. It's needed by staking/slashing tx
 	numMatureOutputs := uint32(300)
 


### PR DESCRIPTION
Execute e2e tests in parallel.
Speed up from `15m` -> `3m`