### PR TITLE
chore(e2e): better port selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly --failfast -timeout=25m -v $(PACKAGES_E2E) -count=1 --parallel 12 --tags=e2e
+	go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=1 --parallel 12 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=15 --parallel 12 --tags=e2e
+	go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=1 --parallel 12 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -race ./...
 
 test-e2e:
-	go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=1 --parallel 12 --tags=e2e
+	go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=15 --parallel 12 --tags=e2e
 
 build-docker:
 	$(DOCKER) build --tag babylonlabs-io/vigilante -f Dockerfile \

--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	bbn "github.com/babylonlabs-io/babylon/types"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/cometbft/cometbft/libs/rand"
 	"net"
 	"regexp"
 	"strconv"
@@ -263,11 +262,8 @@ func randomAvailablePort(t *testing.T) int {
 	// Base port and spread range for port selection
 	const (
 		basePort  = 20000
-		portRange = 20000
+		portRange = 30000
 	)
-
-	// Seed the random number generator to ensure randomness
-	rand.Seed(time.Now().UnixNano())
 
 	// Try up to 10 times to find an available port
 	for i := 0; i < 10; i++ {
@@ -276,6 +272,10 @@ func randomAvailablePort(t *testing.T) int {
 		if err != nil {
 			continue
 		}
+
+		// listen on a port for a bit before closing, this should be just enough time for when other tests start
+		// when they try to net.Listen they should get an err and try a different port
+		time.Sleep(200 * time.Millisecond)
 		if err := listener.Close(); err != nil {
 			continue
 		}

--- a/e2etest/reporter_e2e_test.go
+++ b/e2etest/reporter_e2e_test.go
@@ -54,7 +54,6 @@ func (tm *TestManager) GenerateAndSubmitBlockNBlockStartingFromDepth(t *testing.
 }
 
 func TestReporter_BoostrapUnderFrequentBTCHeaders(t *testing.T) {
-	t.Skip()
 	//t.Parallel() // todo(lazar): this test when run in parallel is very flaky, investigate why
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)

--- a/e2etest/reporter_e2e_test.go
+++ b/e2etest/reporter_e2e_test.go
@@ -54,6 +54,7 @@ func (tm *TestManager) GenerateAndSubmitBlockNBlockStartingFromDepth(t *testing.
 }
 
 func TestReporter_BoostrapUnderFrequentBTCHeaders(t *testing.T) {
+	t.Skip()
 	//t.Parallel() // todo(lazar): this test when run in parallel is very flaky, investigate why
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)

--- a/e2etest/reporter_e2e_test.go
+++ b/e2etest/reporter_e2e_test.go
@@ -54,7 +54,7 @@ func (tm *TestManager) GenerateAndSubmitBlockNBlockStartingFromDepth(t *testing.
 }
 
 func TestReporter_BoostrapUnderFrequentBTCHeaders(t *testing.T) {
-	t.Parallel()
+	//t.Parallel() // todo(lazar): this test when run in parallel is very flaky, investigate why
 	// no need to much mature outputs, we are not going to submit transactions in this test
 	numMatureOutputs := uint32(150)
 

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -1,0 +1,61 @@
+package testutil
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+	"testing"
+)
+
+// Track allocated ports, protected by a mutex
+var (
+	allocatedPorts = make(map[int]struct{})
+	portMutex      sync.Mutex
+)
+
+// AllocateUniquePort tries to find an available TCP port on the localhost
+// by testing multiple random ports within a specified range.
+func AllocateUniquePort(t *testing.T) int {
+	randPort := func(base, spread int) int {
+		return base + rand.Intn(spread)
+	}
+
+	// Base port and spread range for port selection
+	const (
+		basePort  = 20000
+		portRange = 30000
+	)
+
+	// Try up to 10 times to find an available port
+	for i := 0; i < 10; i++ {
+		port := randPort(basePort, portRange)
+
+		// Lock the mutex to check and modify the shared map
+		portMutex.Lock()
+		if _, exists := allocatedPorts[port]; exists {
+			// Port already allocated, try another one
+			portMutex.Unlock()
+			continue
+		}
+
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			portMutex.Unlock()
+			continue
+		}
+
+		allocatedPorts[port] = struct{}{}
+		portMutex.Unlock()
+
+		if err := listener.Close(); err != nil {
+			continue
+		}
+
+		return port
+	}
+
+	// If no available port was found, fail the test
+	t.Fatalf("failed to find an available port in range %d-%d", basePort, basePort+portRange)
+	return 0
+}

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -2,7 +2,7 @@ package testutil
 
 import (
 	"fmt"
-	"math/rand"
+	mrand "math/rand/v2"
 	"net"
 	"sync"
 	"testing"
@@ -18,7 +18,7 @@ var (
 // by testing multiple random ports within a specified range.
 func AllocateUniquePort(t *testing.T) int {
 	randPort := func(base, spread int) int {
-		return base + rand.Intn(spread)
+		return base + mrand.IntN(spread)
 	}
 
 	// Base port and spread range for port selection


### PR DESCRIPTION
Sometimes due to parallel tests, we could end up with the same port allocated. In this PR I try to introduce a small timeout when testing port availability by opening it for a short time which should decrease the chance of collision.

Tested with no collision couple of times with:
```sh
go test -mod=readonly -failfast -timeout=15m -v $(PACKAGES_E2E) -count=30 --parallel 12 --tags=e2e
```

[References issue](https://github.com/babylonlabs-io/vigilante/issues/59)