### PR TITLE
chore(e2e): e2e test for activating and unbonded in mempool

### DIFF
--- a/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
+++ b/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
@@ -113,7 +113,6 @@ func (td *TrackedDelegations) HasDelegationChanged(
 
 	// Compare fields to check if the delegation has changed
 	if existingDelegation.StakingOutputIdx != newDelegation.stakingOutputIdx ||
-		existingDelegation.StakingTx.TxHash() != newDelegation.stakingTx.TxHash() ||
 		!reflect.DeepEqual(existingDelegation.UnbondingOutput, newDelegation.unbondingOutput) ||
 		existingDelegation.DelegationStartHeight != newDelegation.delegationStartHeight {
 		return true, true // The delegation has changed and it exists

--- a/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
+++ b/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
@@ -2,7 +2,6 @@ package stakingeventwatcher
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -111,10 +110,8 @@ func (td *TrackedDelegations) HasDelegationChanged(
 		return false, false
 	}
 
-	// Compare fields to check if the delegation has changed
-	if existingDelegation.StakingOutputIdx != newDelegation.stakingOutputIdx ||
-		!reflect.DeepEqual(existingDelegation.UnbondingOutput, newDelegation.unbondingOutput) ||
-		existingDelegation.DelegationStartHeight != newDelegation.delegationStartHeight {
+	// Compare height to check if the delegation has changed
+	if existingDelegation.DelegationStartHeight != newDelegation.delegationStartHeight {
 		return true, true // The delegation has changed and it exists
 	}
 

--- a/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
+++ b/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
@@ -100,7 +100,7 @@ func (td *TrackedDelegations) RemoveDelegation(stakingTxHash chainhash.Hash) {
 func (td *TrackedDelegations) HasDelegationChanged(
 	stakingTxHash chainhash.Hash,
 	newDelegation *newDelegation,
-) (bool, bool) {
+) (exists bool, changed bool) {
 	td.mu.Lock()
 	defer td.mu.Unlock()
 

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package e2etest
 
 import (

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -201,7 +201,9 @@ func TestActivatingDelegation(t *testing.T) {
 }
 
 // TestActivatingAndUnbondingDelegation tests that delegation will eventually become UNBONDED given that
-// both staking and unbonding tx are in the same block. In this test
+// both staking and unbonding tx are in the same block.
+// In this test, we include both staking tx and unbonding tx in the same block.
+// The delegation goes through "VERIFIED" → "ACTIVE" → "UNBONDED" status throughout this test.
 func TestActivatingAndUnbondingDelegation(t *testing.T) {
 	t.Parallel()
 	// segwit is activated at height 300. It's necessary for staking/slashing tx

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -205,7 +205,7 @@ func TestActivatingDelegation(t *testing.T) {
 // In this test, we include both staking tx and unbonding tx in the same block.
 // The delegation goes through "VERIFIED" → "ACTIVE" → "UNBONDED" status throughout this test.
 func TestActivatingAndUnbondingDelegation(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	// segwit is activated at height 300. It's necessary for staking/slashing tx
 	numMatureOutputs := uint32(300)
 

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -1,9 +1,7 @@
-//go:build e2e
-// +build e2e
-
 package e2etest
 
 import (
+	btcstakingtypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	"go.uber.org/zap"
 	"testing"
 	"time"
@@ -157,7 +155,35 @@ func TestActivatingDelegation(t *testing.T) {
 	// set up a finality provider
 	_, fpSK := tm.CreateFinalityProvider(t)
 	// set up a BTC delegation
-	stakingSlashingInfo, _, _ := tm.CreateBTCDelegationWithoutIncl(t, fpSK)
+	stakingMsgTx, stakingSlashingInfo, _, _ := tm.CreateBTCDelegationWithoutIncl(t, fpSK)
+	stakingMsgTxHash := stakingMsgTx.TxHash()
+
+	// send staking tx to Bitcoin node's mempool
+	_, err = tm.BTCClient.SendRawTransaction(stakingMsgTx, true)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(tm.RetrieveTransactionFromMempool(t, []*chainhash.Hash{&stakingMsgTxHash})) == 1
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+
+	mBlock := tm.mineBlock(t)
+	require.Equal(t, 2, len(mBlock.Transactions))
+
+	// wait until staking tx is on Bitcoin
+	require.Eventually(t, func() bool {
+		_, err := tm.BTCClient.GetRawTransaction(&stakingMsgTxHash)
+		return err == nil
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+
+	// insert k empty blocks to Bitcoin
+	btccParamsResp, err := tm.BabylonClient.BTCCheckpointParams()
+	require.NoError(t, err)
+	btccParams := btccParamsResp.Params
+	for i := 0; i < int(btccParams.BtcConfirmationDepth); i++ {
+		tm.mineBlock(t)
+	}
+
+	tm.CatchUpBTCLightClient(t)
 
 	// created delegation lacks inclusion proof, once created it will be in
 	// pending status, once convenant signatures are added it will be in verified status,
@@ -168,5 +194,117 @@ func TestActivatingDelegation(t *testing.T) {
 		require.NoError(t, err)
 
 		return resp.BtcDelegation.Active
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+}
+
+// TestActivatingAndUnbondingDelegation tests that delegation will eventually become UNBONDED given that
+// both staking and unbonding tx are in the same block. In this test
+func TestActivatingAndUnbondingDelegation(t *testing.T) {
+	t.Parallel()
+	// segwit is activated at height 300. It's necessary for staking/slashing tx
+	numMatureOutputs := uint32(300)
+
+	tm := StartManager(t, numMatureOutputs, defaultEpochInterval)
+	defer tm.Stop(t)
+	// Insert all existing BTC headers to babylon node
+	tm.CatchUpBTCLightClient(t)
+
+	btcNotifier, err := btcclient.NewNodeBackend(
+		btcclient.ToBitcoindConfig(tm.Config.BTC),
+		&chaincfg.RegressionNetParams,
+		&btcclient.EmptyHintCache{},
+	)
+	require.NoError(t, err)
+
+	err = btcNotifier.Start()
+	require.NoError(t, err)
+
+	commonCfg := config.DefaultCommonConfig()
+	bstCfg := config.DefaultBTCStakingTrackerConfig()
+	bstCfg.CheckDelegationsInterval = 1 * time.Second
+	stakingTrackerMetrics := metrics.NewBTCStakingTrackerMetrics()
+
+	bsTracker := bst.NewBTCStakingTracker(
+		tm.BTCClient,
+		btcNotifier,
+		tm.BabylonClient,
+		&bstCfg,
+		&commonCfg,
+		zap.NewNop(),
+		stakingTrackerMetrics,
+	)
+	bsTracker.Start()
+	defer bsTracker.Stop()
+
+	// set up a finality provider
+	_, fpSK := tm.CreateFinalityProvider(t)
+	// set up a BTC delegation
+	stakingMsgTx, stakingSlashingInfo, unbondingSlashingInfo, delSK := tm.CreateBTCDelegationWithoutIncl(t, fpSK)
+	stakingMsgTxHash := stakingMsgTx.TxHash()
+
+	// send staking tx to Bitcoin node's mempool
+	_, err = tm.BTCClient.SendRawTransaction(stakingMsgTx, true)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(tm.RetrieveTransactionFromMempool(t, []*chainhash.Hash{&stakingMsgTxHash})) == 1
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+
+	// Staker unbonds by directly sending tx to btc network. Watcher should detect it and report to babylon.
+	unbondingPathSpendInfo, err := stakingSlashingInfo.StakingInfo.UnbondingPathSpendInfo()
+	require.NoError(t, err)
+	stakingOutIdx, err := outIdx(unbondingSlashingInfo.UnbondingTx, unbondingSlashingInfo.UnbondingInfo.UnbondingOutput)
+	require.NoError(t, err)
+
+	unbondingTxSchnorrSig, err := btcstaking.SignTxWithOneScriptSpendInputStrict(
+		unbondingSlashingInfo.UnbondingTx,
+		stakingSlashingInfo.StakingTx,
+		stakingOutIdx,
+		unbondingPathSpendInfo.GetPkScriptPath(),
+		delSK,
+	)
+	require.NoError(t, err)
+
+	resp, err := tm.BabylonClient.BTCDelegation(stakingSlashingInfo.StakingTx.TxHash().String())
+	require.NoError(t, err)
+
+	covenantSigs := resp.BtcDelegation.UndelegationResponse.CovenantUnbondingSigList
+	witness, err := unbondingPathSpendInfo.CreateUnbondingPathWitness(
+		[]*schnorr.Signature{covenantSigs[0].Sig.MustToBTCSig()},
+		unbondingTxSchnorrSig,
+	)
+	require.NoError(t, err)
+	unbondingSlashingInfo.UnbondingTx.TxIn[0].Witness = witness
+
+	// Send unbonding tx to Bitcoin
+	_, err = tm.BTCClient.SendRawTransaction(unbondingSlashingInfo.UnbondingTx, true)
+	require.NoError(t, err)
+
+	unbondingTxHash := unbondingSlashingInfo.UnbondingTx.TxHash()
+	t.Logf("submitted unbonding tx with hash %s", unbondingTxHash.String())
+	require.Eventually(t, func() bool {
+		return len(tm.RetrieveTransactionFromMempool(t, []*chainhash.Hash{&unbondingTxHash})) == 1
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+
+	mBlock := tm.mineBlock(t)
+	// both staking and unbonding txs are in this block
+	require.Equal(t, 3, len(mBlock.Transactions))
+
+	// insert k empty blocks to Bitcoin
+	btccParamsResp, err := tm.BabylonClient.BTCCheckpointParams()
+	require.NoError(t, err)
+	btccParams := btccParamsResp.Params
+	for i := 0; i < int(btccParams.BtcConfirmationDepth); i++ {
+		tm.mineBlock(t)
+	}
+
+	tm.CatchUpBTCLightClient(t)
+
+	// wait until delegation has become unbonded
+	require.Eventually(t, func() bool {
+		resp, err := tm.BabylonClient.BTCDelegation(stakingSlashingInfo.StakingTx.TxHash().String())
+		require.NoError(t, err)
+
+		return resp.BtcDelegation.StatusDesc == btcstakingtypes.BTCDelegationStatus_UNBONDED.String()
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 }


### PR DESCRIPTION
This PR introduces an end-to-end test to validate that when both a staking transaction and an unbonding transaction are included in the same block, the delegation correctly transitions to the "UNBONDED" status.
