### PR TITLE
chore(goreleaser): static amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,18 +8,26 @@ builds:
     binary: vigilante
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm_muslc.x86_64.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a
     goos:
       - linux
     goarch:
       - amd64
     env:
       - GO111MODULE=on
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+    ldflags:
+      - -w -s
+      - -linkmode=external
+      - -extldflags '-Wl,-z,muldefs -static'
     flags:
       - -mod=readonly
       - -trimpath
     tags:
       - netgo
+      - ledger
+      - muslc
       - osusergo
 
   - id: vigilante-darwin-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,11 @@ builds:
     binary: vigilante
     hooks:
       pre:
+        - apt update && apt install -y wget libc6-dev libc6-dev-static musl-tools
+        - find /usr -name 'libm.a'
+        - find /usr -name 'libmvec.a'
+        - mv /usr/x86_64-linux-gnu/lib/libm.a /usr/x86_64-linux-gnu/libm-2.31.a
+        - mv /usr/x86_64-linux-gnu/lib/libmvec.a /usr/lib/x86_64-linux-gnu/libmvec.a
         - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a
     goos:
       - linux
@@ -20,7 +25,7 @@ builds:
     ldflags:
       - -w -s
       - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static'
+      - -extldflags '-Wl,-z,muldefs -static -lpthread -lm'
     flags:
       - -mod=readonly
       - -trimpath
@@ -30,31 +35,32 @@ builds:
       - muslc
       - osusergo
 
-  - id: vigilante-darwin-arm64
-    main: ./cmd/vigilante/main.go
-    binary: vigilante
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    env:
-      - GO111MODULE=on
-      - CGO_ENABLED=1
-      - CC=oa64-clang
-      - CGO_LDFLAGS=-L/lib -Wl,-rpath,/lib
-    ldflags:
-      - -w -s
-      - -linkmode=external
-    flags:
-      - -mod=readonly
-      - -trimpath
-    tags:
-      - netgo
-      - ledger
-      - static_wasm
+# todo uncomment
+#  - id: vigilante-darwin-arm64
+#    main: ./cmd/vigilante/main.go
+#    binary: vigilante
+#    hooks:
+#      pre:
+#        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+#    goos:
+#      - darwin
+#    goarch:
+#      - arm64
+#    env:
+#      - GO111MODULE=on
+#      - CGO_ENABLED=1
+#      - CC=oa64-clang
+#      - CGO_LDFLAGS=-L/lib -Wl,-rpath,/lib
+#    ldflags:
+#      - -w -s
+#      - -linkmode=external
+#    flags:
+#      - -mod=readonly
+#      - -trimpath
+#    tags:
+#      - netgo
+#      - ledger
+#      - static_wasm
 
 archives:
   - id: zipped

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,6 @@ builds:
     binary: vigilante
     hooks:
       pre:
-        - apt update && apt install -y wget libc6-dev libc6-dev-static musl-tools
-        - find /usr -name 'libm.a'
-        - find /usr -name 'libmvec.a'
-        - mv /usr/x86_64-linux-gnu/lib/libm.a /usr/x86_64-linux-gnu/libm-2.31.a
-        - mv /usr/x86_64-linux-gnu/lib/libmvec.a /usr/lib/x86_64-linux-gnu/libmvec.a
         - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a
     goos:
       - linux
@@ -25,7 +20,7 @@ builds:
     ldflags:
       - -w -s
       - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static -lpthread -lm'
+      - -extldflags '-Wl,-z,muldefs -static -lm'
     flags:
       - -mod=readonly
       - -trimpath


### PR DESCRIPTION
run `make release-snapshot`, the amd64 build fails due some misconfiguration in static linking **[help needed]**. I am running this on M3 mac

```sh
command-line-arguments
/usr/local/go/pkg/tool/linux_arm64/link: running x86_64-linux-gnu-gcc failed: exit status 1
/usr/bin/x86_64-linux-gnu-gcc -m64 -s -o $WORK/b001/exe/a.out -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=cCanonicalizeAddress -Wl,--export-dynamic-symbol=cDelete -Wl,--export-dynamic-symbol=cGet -Wl,--export-dynamic-symbol=cHumanizeAddress -Wl,--export-dynamic-symbol=cNext -Wl,--export-dynamic-symbol=cNextKey -Wl,--export-dynamic-symbol=cNextValue -Wl,--export-dynamic-symbol=cQueryExternal -Wl,--export-dynamic-symbol=cScan -Wl,--export-dynamic-symbol=cSet -Wl,--export-dynamic-symbol=cValidateAddress -Wl,--export-dynamic-symbol=crosscall2 -Wl,--export-dynamic-symbol=secp256k1GoPanicError -Wl,--export-dynamic-symbol=secp256k1GoPanicIllegal -Wl,--compress-debug-sections=zlib /tmp/go-link-2183027264/go.o /tmp/go-link-2183027264/000000.o /tmp/go-link-2183027264/000001.o /tmp/go-link-2183027264/000002.o /tmp/go-link-2183027264/000003.o /tmp/go-link-2183027264/000004.o /tmp/go-link-2183027264/000005.o /tmp/go-link-2183027264/000006.o /tmp/go-link-2183027264/000007.o /tmp/go-link-2183027264/000008.o /tmp/go-link-2183027264/000009.o /tmp/go-link-2183027264/000010.o /tmp/go-link-2183027264/000011.o /tmp/go-link-2183027264/000012.o /tmp/go-link-2183027264/000013.o /tmp/go-link-2183027264/000014.o /tmp/go-link-2183027264/000015.o /tmp/go-link-2183027264/000016.o /tmp/go-link-2183027264/000017.o /tmp/go-link-2183027264/000018.o /tmp/go-link-2183027264/000019.o /tmp/go-link-2183027264/000020.o /tmp/go-link-2183027264/000021.o /tmp/go-link-2183027264/000022.o /tmp/go-link-2183027264/000023.o /tmp/go-link-2183027264/000024.o /tmp/go-link-2183027264/000025.o /tmp/go-link-2183027264/000026.o /tmp/go-link-2183027264/000027.o /tmp/go-link-2183027264/000028.o /tmp/go-link-2183027264/000029.o /tmp/go-link-2183027264/000030.o /tmp/go-link-2183027264/000031.o -O2 -g -O2 -g -O2 -g -lpthread -O2 -g -Wl,-rpath,/root/go/pkg/mod/github.com/!cosm!wasm/wasmvm/v2@v2.1.2/internal/api -L/root/go/pkg/mod/github.com/!cosm!wasm/wasmvm/v2@v2.1.2/internal/api -lwasmvm_muslc.x86_64 -O2 -g -lrt -no-pie -Wl,-z,muldefs -static
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `std::sys::pal::unix::os::home_dir::fallback':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/os.rs:732: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `<std::sys_common::net::LookupHost as core::convert::TryFrom<(&str,u16)>>::try_from::{{closure}}':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys_common/net.rs:207: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_compiler-00c72df1dcee60df.wasmer_compiler.c346b283a3dbd616-cgu.04.rcgu.o): in function `wasmer_compiler::engine::unwind::systemv::UnwindRegistry::publish':
wasmer_compiler.c346b283a3dbd616-cgu.04:(.text._ZN15wasmer_compiler6engine6unwind7systemv14UnwindRegistry7publish17h938519e06edbd158E+0xc1): undefined reference to `dlsym'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `std::sys::pal::unix::thread::Thread::new':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/thread.rs:71: undefined reference to `pthread_attr_setstacksize'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/thread.rs:82: undefined reference to `pthread_attr_setstacksize'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `std::sys::pal::unix::thread::Thread::set_name':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/thread.rs:140: undefined reference to `pthread_setname_np'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(std-742797dd06d019e7.std.e4c3ebae17ee837d-cgu.0.rcgu.o): in function `std::sys::pal::unix::thread::guard::current':
/rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/sys/pal/unix/thread.rs:925: undefined reference to `pthread_attr_getguardsize'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f32_ceil':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_ceil+0x2): undefined reference to `ceilf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f32_floor':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_floor+0x2): undefined reference to `floorf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f32_trunc':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_trunc+0x2): undefined reference to `truncf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f32_nearest':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_nearest+0x1e): undefined reference to `ceilf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_nearest+0x2d): undefined reference to `floorf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f32_nearest+0x75): undefined reference to `floorf'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f64_ceil':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_ceil+0x2): undefined reference to `ceil'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f64_floor':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_floor+0x2): undefined reference to `floor'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f64_trunc':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_trunc+0x2): undefined reference to `trunc'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.x86_64.a(wasmer_vm-c529e0c1d2ca8ce6.wasmer_vm.310c87423edf2eaf-cgu.13.rcgu.o): in function `wasmer_vm_f64_nearest':
wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_nearest+0x24): undefined reference to `ceil'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_nearest+0x35): undefined reference to `floor'
/usr/lib/gcc-cross/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/bin/ld: wasmer_vm.310c87423edf2eaf-cgu.13:(.text.wasmer_vm_f64_nearest+0x88): undefined reference to `floor'
collect2: error: ld returned 1 exit status


```