### PR TITLE
feat(sew): ADR-029 generalized unbonding and babylon v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#84](https://github.com/babylonlabs-io/vigilante/pull/84) fix spawning more go routines than needed when activating 
 delegations, add more logging
 
+### Improvements
+* [#87](https://github.com/babylonlabs-io/vigilante/pull/87) adr 029 for generalized unbonding
 
 ## v0.13.0
 

--- a/btcstaking-tracker/btcslasher/bootstrapping_test.go
+++ b/btcstaking-tracker/btcslasher/bootstrapping_test.go
@@ -98,8 +98,17 @@ func FuzzSlasher_Bootstrapping(f *testing.F) {
 		// mock an evidence with this finality provider
 		evidence, err := datagen.GenRandomEvidence(r, fpSK, 100)
 		require.NoError(t, err)
+		er := &ftypes.EvidenceResponse{
+			FpBtcPkHex:           evidence.FpBtcPk.MarshalHex(),
+			BlockHeight:          evidence.BlockHeight,
+			PubRand:              evidence.PubRand,
+			CanonicalAppHash:     evidence.CanonicalAppHash,
+			ForkAppHash:          evidence.ForkAppHash,
+			CanonicalFinalitySig: evidence.CanonicalFinalitySig,
+			ForkFinalitySig:      evidence.ForkFinalitySig,
+		}
 		mockBabylonQuerier.EXPECT().ListEvidences(gomock.Any(), gomock.Any()).Return(&ftypes.QueryListEvidencesResponse{
-			Evidences:  []*ftypes.Evidence{evidence},
+			Evidences:  []*ftypes.EvidenceResponse{er},
 			Pagination: &query.PageResponse{NextKey: nil},
 		}, nil).Times(1)
 

--- a/btcstaking-tracker/btcslasher/slasher_test.go
+++ b/btcstaking-tracker/btcslasher/slasher_test.go
@@ -261,10 +261,10 @@ func FuzzSlasher(f *testing.F) {
 			err = unbondingSlashingInfo.UnbondingTx.Serialize(&unbondingTxBuffer)
 			require.NoError(t, err)
 			unbondingBTCDel.BtcUndelegation = &bstypes.BTCUndelegation{
-				UnbondingTx:           unbondingTxBuffer.Bytes(),
-				SlashingTx:            unbondingSlashingInfo.SlashingTx,
-				DelegatorSlashingSig:  delSlashingSig,
-				DelegatorUnbondingSig: delSlashingSig,
+				UnbondingTx:            unbondingTxBuffer.Bytes(),
+				SlashingTx:             unbondingSlashingInfo.SlashingTx,
+				DelegatorSlashingSig:   delSlashingSig,
+				DelegatorUnbondingInfo: &bstypes.DelegatorUnbondingInfo{SpendStakeTx: unbondingTxBuffer.Bytes()},
 				// TODO: currently requires only one sig, in reality requires all of them
 				CovenantSlashingSigs:     covenantSlashingSigs,
 				CovenantUnbondingSigList: covenantUnbondingSigs,

--- a/btcstaking-tracker/btcslasher/slasher_utils.go
+++ b/btcstaking-tracker/btcslasher/slasher_utils.go
@@ -423,8 +423,7 @@ func (bs *BTCSlasher) getAllActiveAndUnbondedBTCDelegations(
 					activeDels = append(activeDels, dels.Dels[i])
 				}
 				if strings.EqualFold(del.StatusDesc, bstypes.BTCDelegationStatus_UNBONDED.String()) &&
-					len(del.UndelegationResponse.CovenantSlashingSigs) >= int(bsParams.CovenantQuorum) &&
-					len(del.UndelegationResponse.DelegatorUnbondingInfoResponse.SpendStakeTxHex) > 0 {
+					len(del.UndelegationResponse.CovenantSlashingSigs) >= int(bsParams.CovenantQuorum) {
 					// NOTE: Babylon considers a BTC delegation to be unbonded once it
 					// receives staker signature for unbonding transaction, no matter
 					// whether the unbonding tx's timelock has expired. In monitor's view we need to try to slash every

--- a/btcstaking-tracker/btcslasher/slasher_utils.go
+++ b/btcstaking-tracker/btcslasher/slasher_utils.go
@@ -424,7 +424,7 @@ func (bs *BTCSlasher) getAllActiveAndUnbondedBTCDelegations(
 				}
 				if strings.EqualFold(del.StatusDesc, bstypes.BTCDelegationStatus_UNBONDED.String()) &&
 					len(del.UndelegationResponse.CovenantSlashingSigs) >= int(bsParams.CovenantQuorum) &&
-					len(del.UndelegationResponse.DelegatorUnbondingSigHex) > 0 {
+					len(del.UndelegationResponse.DelegatorUnbondingInfoResponse.SpendStakeTxHex) > 0 {
 					// NOTE: Babylon considers a BTC delegation to be unbonded once it
 					// receives staker signature for unbonding transaction, no matter
 					// whether the unbonding tx's timelock has expired. In monitor's view we need to try to slash every

--- a/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
+++ b/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
@@ -10,8 +10,8 @@ import (
 
 	types "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	types0 "github.com/babylonlabs-io/babylon/x/btcstaking/types"
-	schnorr "github.com/btcsuite/btcd/btcec/v2/schnorr"
 	chainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+	wire "github.com/btcsuite/btcd/wire"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -113,15 +113,15 @@ func (mr *MockBabylonNodeAdapterMockRecorder) IsDelegationVerified(stakingTxHash
 }
 
 // ReportUnbonding mocks base method.
-func (m *MockBabylonNodeAdapter) ReportUnbonding(ctx context.Context, stakingTxHash chainhash.Hash, stakerUnbondingSig *schnorr.Signature) error {
+func (m *MockBabylonNodeAdapter) ReportUnbonding(ctx context.Context, stakingTxHash chainhash.Hash, stakeSpendingTx *wire.MsgTx, inclusionProof *types0.InclusionProof) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportUnbonding", ctx, stakingTxHash, stakerUnbondingSig)
+	ret := m.ctrl.Call(m, "ReportUnbonding", ctx, stakingTxHash, stakeSpendingTx, inclusionProof)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportUnbonding indicates an expected call of ReportUnbonding.
-func (mr *MockBabylonNodeAdapterMockRecorder) ReportUnbonding(ctx, stakingTxHash, stakerUnbondingSig interface{}) *gomock.Call {
+func (mr *MockBabylonNodeAdapterMockRecorder) ReportUnbonding(ctx, stakingTxHash, stakeSpendingTx, inclusionProof interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportUnbonding", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).ReportUnbonding), ctx, stakingTxHash, stakerUnbondingSig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportUnbonding", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).ReportUnbonding), ctx, stakingTxHash, stakeSpendingTx, inclusionProof)
 }

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -444,7 +444,6 @@ func (sew *StakingEventWatcher) watchForSpend(spendEvent *notifier.SpendEvent, t
 			return
 		}
 		sew.reportUnbondingToBabylon(quitCtx, delegationId, spendingTx, proof)
-		sew.waitForDelegationToStopBeingActive(quitCtx, delegationId)
 	} else {
 		sew.metrics.DetectedUnbondingTransactionsCounter.Inc()
 		// We found valid unbonding tx. We need to try to report it to babylon.

--- a/e2etest/atomicslasher_e2e_test.go
+++ b/e2etest/atomicslasher_e2e_test.go
@@ -218,7 +218,7 @@ func TestAtomicSlasher_Unbonding(t *testing.T) {
 	/*
 		the victim BTC delegation unbonds
 	*/
-	tm.Undelegate(t, stakingSlashingInfo, unbondingSlashingInfo, btcDelSK)
+	tm.Undelegate(t, stakingSlashingInfo, unbondingSlashingInfo, btcDelSK, func() { tm.CatchUpBTCLightClient(t) })
 
 	/*
 		finality provider builds unbonding slashing tx witness and sends it to Bitcoin

--- a/e2etest/container/config.go
+++ b/e2etest/container/config.go
@@ -24,14 +24,13 @@ const (
 
 // NewImageConfig returns ImageConfig needed for running e2e test.
 func NewImageConfig(t *testing.T) ImageConfig {
-	babylondVersion, err := testutil.GetBabylonVersion()
+	_, err := testutil.GetBabylonVersion()
 	require.NoError(t, err)
-	babylondVersion = "6a0ccacc41435a249316a77fe6e1e06aeb654d13" // todo(lazar): remove this when we have a tag
 
 	return ImageConfig{
 		BitcoindRepository: dockerBitcoindRepository,
 		BitcoindVersion:    dockerBitcoindVersionTag,
 		BabylonRepository:  dockerBabylondRepository,
-		BabylonVersion:     babylondVersion,
+		BabylonVersion:     "6a0ccacc41435a249316a77fe6e1e06aeb654d13", // todo(lazar): remove this when we have a tag
 	}
 }

--- a/e2etest/container/config.go
+++ b/e2etest/container/config.go
@@ -26,6 +26,7 @@ const (
 func NewImageConfig(t *testing.T) ImageConfig {
 	babylondVersion, err := testutil.GetBabylonVersion()
 	require.NoError(t, err)
+	babylondVersion = "6a0ccacc41435a249316a77fe6e1e06aeb654d13" // todo(lazar): remove this when we have a tag
 
 	return ImageConfig{
 		BitcoindRepository: dockerBitcoindRepository,

--- a/e2etest/container/config.go
+++ b/e2etest/container/config.go
@@ -24,13 +24,13 @@ const (
 
 // NewImageConfig returns ImageConfig needed for running e2e test.
 func NewImageConfig(t *testing.T) ImageConfig {
-	_, err := testutil.GetBabylonVersion()
+	babylonVersion, err := testutil.GetBabylonVersion()
 	require.NoError(t, err)
 
 	return ImageConfig{
 		BitcoindRepository: dockerBitcoindRepository,
 		BitcoindVersion:    dockerBitcoindVersionTag,
 		BabylonRepository:  dockerBabylondRepository,
-		BabylonVersion:     "6a0ccacc41435a249316a77fe6e1e06aeb654d13", // todo(lazar): remove this when we have a tag
+		BabylonVersion:     babylonVersion,
 	}
 }

--- a/e2etest/slasher_e2e_test.go
+++ b/e2etest/slasher_e2e_test.go
@@ -187,7 +187,7 @@ func TestSlasher_SlashingUnbonding(t *testing.T) {
 	stakingSlashingInfo1, unbondingSlashingInfo1, stakerPrivKey1 := tm.CreateBTCDelegation(t, fpSK)
 
 	// undelegate
-	unbondingSlashingInfo, _ := tm.Undelegate(t, stakingSlashingInfo1, unbondingSlashingInfo1, stakerPrivKey1)
+	unbondingSlashingInfo, _ := tm.Undelegate(t, stakingSlashingInfo1, unbondingSlashingInfo1, stakerPrivKey1, func() { tm.CatchUpBTCLightClient(t) })
 
 	// commit public randomness, vote and equivocate
 	tm.VoteAndEquivocate(t, fpSK)

--- a/e2etest/test_manager_btcstaking.go
+++ b/e2etest/test_manager_btcstaking.go
@@ -472,7 +472,8 @@ func (tm *TestManager) Undelegate(
 	t *testing.T,
 	stakingSlashingInfo *datagen.TestStakingSlashingInfo,
 	unbondingSlashingInfo *datagen.TestUnbondingSlashingInfo,
-	delSK *btcec.PrivateKey) (*datagen.TestUnbondingSlashingInfo, *schnorr.Signature) {
+	delSK *btcec.PrivateKey,
+	catchUpLightClientFunc func()) (*datagen.TestUnbondingSlashingInfo, *schnorr.Signature) {
 	signerAddr := tm.BabylonClient.MustGetAddr()
 
 	// TODO: This generates unbonding tx signature, move it to undelegate
@@ -494,16 +495,6 @@ func (tm *TestManager) Undelegate(
 	var unbondingTxBuf bytes.Buffer
 	err = unbondingSlashingInfo.UnbondingTx.Serialize(&unbondingTxBuf)
 	require.NoError(t, err)
-
-	msgUndel := &bstypes.MsgBTCUndelegate{
-		Signer:                        signerAddr,
-		StakingTxHash:                 stakingSlashingInfo.StakingTx.TxHash().String(),
-		StakeSpendingTx:               unbondingTxBuf.Bytes(),
-		StakeSpendingTxInclusionProof: nil,
-	}
-	_, err = tm.BabylonClient.ReliablySendMsg(context.Background(), msgUndel, nil, nil)
-	require.NoError(t, err)
-	t.Logf("submitted MsgBTCUndelegate")
 
 	resp, err := tm.BabylonClient.BTCDelegation(stakingSlashingInfo.StakingTx.TxHash().String())
 	require.NoError(t, err)
@@ -531,6 +522,22 @@ func (tm *TestManager) Undelegate(
 
 	mBlock := tm.mineBlock(t)
 	require.Equal(t, 2, len(mBlock.Transactions))
+
+	catchUpLightClientFunc()
+
+	unbondingTxInfo := getTxInfo(t, mBlock)
+	msgUndel := &bstypes.MsgBTCUndelegate{
+		Signer:          signerAddr,
+		StakingTxHash:   stakingSlashingInfo.StakingTx.TxHash().String(),
+		StakeSpendingTx: unbondingTxBuf.Bytes(),
+		StakeSpendingTxInclusionProof: &bstypes.InclusionProof{
+			Key:   unbondingTxInfo.Key,
+			Proof: unbondingTxInfo.Proof,
+		},
+	}
+	_, err = tm.BabylonClient.ReliablySendMsg(context.Background(), msgUndel, nil, nil)
+	require.NoError(t, err)
+	t.Logf("submitted MsgBTCUndelegate")
 
 	// wait until unbonding tx is on Bitcoin
 	require.Eventually(t, func() bool {

--- a/e2etest/test_manager_btcstaking.go
+++ b/e2etest/test_manager_btcstaking.go
@@ -491,10 +491,15 @@ func (tm *TestManager) Undelegate(
 	)
 	require.NoError(t, err)
 
+	var unbondingTxBuf bytes.Buffer
+	err = unbondingSlashingInfo.UnbondingTx.Serialize(&unbondingTxBuf)
+	require.NoError(t, err)
+
 	msgUndel := &bstypes.MsgBTCUndelegate{
-		Signer:         signerAddr,
-		StakingTxHash:  stakingSlashingInfo.StakingTx.TxHash().String(),
-		UnbondingTxSig: bbn.NewBIP340SignatureFromBTCSig(unbondingTxSchnorrSig),
+		Signer:                        signerAddr,
+		StakingTxHash:                 stakingSlashingInfo.StakingTx.TxHash().String(),
+		StakeSpendingTx:               unbondingTxBuf.Bytes(),
+		StakeSpendingTxInclusionProof: nil,
 	}
 	_, err = tm.BabylonClient.ReliablySendMsg(context.Background(), msgUndel, nil, nil)
 	require.NoError(t, err)

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -103,6 +103,8 @@ func TestUnbondingWatcher(t *testing.T) {
 	minedBlock := tm.mineBlock(t)
 	require.Equal(t, 2, len(minedBlock.Transactions))
 
+	tm.CatchUpBTCLightClient(t)
+
 	require.Eventually(t, func() bool {
 		resp, err := tm.BabylonClient.BTCDelegation(stakingSlashingInfo.StakingTx.TxHash().String())
 		require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cosmossdk.io/log v1.4.1
 	cosmossdk.io/math v1.3.0
 	github.com/avast/retry-go/v4 v4.6.0
-	github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143
+	github.com/babylonlabs-io/babylon v0.14.0
 	github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cosmossdk.io/log v1.4.1
 	cosmossdk.io/math v1.3.0
 	github.com/avast/retry-go/v4 v4.6.0
-	github.com/babylonlabs-io/babylon v0.13.0
+	github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143
 	github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
@@ -66,7 +66,7 @@ require (
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/CosmWasm/wasmd v0.53.0 // indirect
-	github.com/CosmWasm/wasmvm/v2 v2.1.2 // indirect
+	github.com/CosmWasm/wasmvm/v2 v2.1.3 // indirect
 	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143 h1:pHxychHq/tceH2wVImt6fLuXesBTQ4d+6mMRgpjzidw=
-github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143/go.mod h1:xaxDB8/sJWhqTw0BkmNzYtsOzIlpKAAnmXg8xJRbCjk=
+github.com/babylonlabs-io/babylon v0.14.0 h1:JyqkRD+vk4voapWU05pgi26SCNsNT00BmE9seheTDe0=
+github.com/babylonlabs-io/babylon v0.14.0/go.mod h1:xaxDB8/sJWhqTw0BkmNzYtsOzIlpKAAnmXg8xJRbCjk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CosmWasm/wasmd v0.53.0 h1:kdaoAi20bIb4VCsxw9pRaT2g5PpIp82Wqrr9DRVN9ao=
 github.com/CosmWasm/wasmd v0.53.0/go.mod h1:FJl/aWjdpGof3usAMFQpDe07Rkx77PUzp0cygFMOvtw=
-github.com/CosmWasm/wasmvm/v2 v2.1.2 h1:GkJ5bAsRlLHfIQVg/FY1VHwLyBwlCjAhDea0B8L+e20=
-github.com/CosmWasm/wasmvm/v2 v2.1.2/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
+github.com/CosmWasm/wasmvm/v2 v2.1.3 h1:CSJTauZqkHyb9yic6JVYCjiGUgxI2MJV2QzfSu8m49c=
+github.com/CosmWasm/wasmvm/v2 v2.1.3/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
@@ -283,8 +283,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonlabs-io/babylon v0.13.0 h1:h7cazmFmItePvZHEbLhDbsq2l7xN4e2AjDHRM7zDLkg=
-github.com/babylonlabs-io/babylon v0.13.0/go.mod h1:cxRwVqVLoJ39FpyovTEHJLu1lwwrM1tE8davu7nRHwY=
+github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143 h1:pHxychHq/tceH2wVImt6fLuXesBTQ4d+6mMRgpjzidw=
+github.com/babylonlabs-io/babylon v0.0.0-20241022090919-6a0ccacc4143/go.mod h1:xaxDB8/sJWhqTw0BkmNzYtsOzIlpKAAnmXg8xJRbCjk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Extends staking event watcher to be able to send whole stake spending tx as well as inclusion proof.

