### PR TITLE
chore(sew): measure latency (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+* [#105](https://github.com/babylonlabs-io/vigilante/pull/105) Measure latency
+
 ## v0.16.0
 
 * [#94](https://github.com/babylonlabs-io/vigilante/pull/94) adds gosec and fixes gosec issues

--- a/metrics/btcstaking_tracker.go
+++ b/metrics/btcstaking_tracker.go
@@ -31,6 +31,7 @@ type UnbondingWatcherMetrics struct {
 	DetectedNonUnbondingTransactionsCounter prometheus.Counter
 	FailedReportedActivateDelegations       prometheus.Counter
 	ReportedActivateDelegationsCounter      prometheus.Counter
+	MethodExecutionLatency                  *prometheus.HistogramVec
 }
 
 func newUnbondingWatcherMetrics(registry *prometheus.Registry) *UnbondingWatcherMetrics {
@@ -66,6 +67,11 @@ func newUnbondingWatcherMetrics(registry *prometheus.Registry) *UnbondingWatcher
 			Name: "unbonding_watcher_reported_activate_delegations",
 			Help: "The total number of unbonding transactions successfully reported to Babylon node",
 		}),
+		MethodExecutionLatency: registerer.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "unbonding_watcher_method_latency_seconds",
+			Help:    "Latency in seconds",
+			Buckets: []float64{.001, .002, .005, .01, .025, .05, .1},
+		}, []string{"method"}),
 	}
 
 	return uwMetrics


### PR DESCRIPTION
Measure the latency of certain functions. We need more context about fcn execution.

Related to debugging
[issue](https://github.com/babylonlabs-io/vigilante/issues/101)