### PR TITLE
chore: backport goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,9 +6,6 @@ builds:
   - id: vigilante-linux-amd64
     main: ./cmd/vigilante/main.go
     binary: vigilante
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm_muslc.x86_64.a
     goos:
       - linux
     goarch:
@@ -18,6 +15,8 @@ builds:
     flags:
       - -mod=readonly
       - -trimpath
+    ldflags:
+      - -w -s
     tags:
       - netgo
       - osusergo
@@ -27,7 +26,7 @@ builds:
     binary: vigilante
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.1.3/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     goos:
       - darwin
     goarch:
@@ -59,6 +58,20 @@ archives:
   - id: binaries
     builds:
       - vigilante-linux-amd64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    files:
+      - none*
+  - id: zipped-arm64
+    builds:
+      - vigilante-darwin-arm64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: tar.gz
+    files:
+      - none*
+  - id: binaries-arm64
+    builds:
+      - vigilante-darwin-arm64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+* [#113](https://github.com/babylonlabs-io/vigilante/pull/113) goreleaser wasm version
+
+
 ## v0.17.0
 
 ### Improvements


### PR DESCRIPTION
fix goreleaser