### PR TITLE
chore(sew): improvments to staking event tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#127](https://github.com/babylonlabs-io/vigilante/pull/127) fix long lock time
+
 ## v0.17.2
 
 ### Improvements

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -634,6 +634,7 @@ func (sew *StakingEventWatcher) activateBtcDelegation(
 	defer cancel()
 
 	defer sew.latency("activateBtcDelegation")()
+	defer sew.inProgressTracker.RemoveDelegation(stakingTxHash)
 
 	sew.waitForRequiredDepth(ctx, stakingTxHash, &inclusionBlockHash, requiredDepth)
 

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -612,7 +612,7 @@ func (sew *StakingEventWatcher) checkBtcForStakingTx() {
 		}
 
 		if _, err = sew.inProgressTracker.AddDel(del, false); err != nil {
-			sew.logger.Debugf("error adding del %s", err)
+			sew.logger.Warnf("add del: %s", err)
 			continue
 		}
 

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -659,7 +659,6 @@ func (sew *StakingEventWatcher) activateBtcDelegation(
 		sew.metrics.ReportedActivateDelegationsCounter.Inc()
 
 		sew.pendingTracker.RemoveDelegation(stakingTxHash)
-		sew.inProgressTracker.RemoveDelegation(stakingTxHash)
 
 		sew.metrics.NumberOfVerifiedDelegations.Dec()
 		sew.logger.Debugf("staking tx activated %s", stakingTxHash.String())

--- a/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
+++ b/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
@@ -105,6 +105,28 @@ func (td *TrackedDelegations) AddDelegation(
 	return delegation, nil
 }
 
+func (td *TrackedDelegations) AddDel(
+	delegation *TrackedDelegation,
+	shouldUpdate bool,
+) (*TrackedDelegation, error) {
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	stakingTxHash := delegation.StakingTx.TxHash()
+
+	if _, ok := td.mapping[stakingTxHash]; ok {
+		if shouldUpdate {
+			// Update the existing delegation
+			td.mapping[stakingTxHash] = delegation
+			return delegation, nil
+		}
+		return nil, fmt.Errorf("delegation already tracked for staking tx hash %s", stakingTxHash)
+	}
+
+	td.mapping[stakingTxHash] = delegation
+	return delegation, nil
+}
+
 func (td *TrackedDelegations) RemoveDelegation(stakingTxHash chainhash.Hash) {
 	td.mu.Lock()
 	defer td.mu.Unlock()

--- a/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
+++ b/btcstaking-tracker/stakingeventwatcher/tracked_delegations.go
@@ -105,28 +105,6 @@ func (td *TrackedDelegations) AddDelegation(
 	return delegation, nil
 }
 
-func (td *TrackedDelegations) AddDel(
-	delegation *TrackedDelegation,
-	shouldUpdate bool,
-) (*TrackedDelegation, error) {
-	td.mu.Lock()
-	defer td.mu.Unlock()
-
-	stakingTxHash := delegation.StakingTx.TxHash()
-
-	if _, ok := td.mapping[stakingTxHash]; ok {
-		if shouldUpdate {
-			// Update the existing delegation
-			td.mapping[stakingTxHash] = delegation
-			return delegation, nil
-		}
-		return nil, fmt.Errorf("delegation already tracked for staking tx hash %s", stakingTxHash)
-	}
-
-	td.mapping[stakingTxHash] = delegation
-	return delegation, nil
-}
-
 func (td *TrackedDelegations) RemoveDelegation(stakingTxHash chainhash.Hash) {
 	td.mu.Lock()
 	defer td.mu.Unlock()

--- a/metrics/btcstaking_tracker.go
+++ b/metrics/btcstaking_tracker.go
@@ -32,6 +32,7 @@ type UnbondingWatcherMetrics struct {
 	FailedReportedActivateDelegations       prometheus.Counter
 	ReportedActivateDelegationsCounter      prometheus.Counter
 	NumberOfActivationInProgress            prometheus.Gauge
+	NumberOfVerifiedDelegations             prometheus.Gauge
 	MethodExecutionLatency                  *prometheus.HistogramVec
 }
 
@@ -85,6 +86,11 @@ func newUnbondingWatcherMetrics(registry *prometheus.Registry) *UnbondingWatcher
 			Namespace: "vigilante",
 			Name:      "unbonding_watcher_number_of_activation_in_progress",
 			Help:      "The number of activations in progress",
+		}),
+		NumberOfVerifiedDelegations: registerer.NewGauge(prometheus.GaugeOpts{
+			Namespace: "vigilante",
+			Name:      "unbonding_watcher_number_of_verified_delegations",
+			Help:      "The number of verified delegations",
 		}),
 	}
 


### PR DESCRIPTION
This should solve a long lock wait time, which happens when fetching delegations into the tracker and trying to update a tracker