### PR TITLE
chore(sew): improvments to staking event tracker (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#127](https://github.com/babylonlabs-io/vigilante/pull/127) fix long lock time
+
 ## v0.17.2
 
 ### Improvements

--- a/metrics/btcstaking_tracker.go
+++ b/metrics/btcstaking_tracker.go
@@ -32,6 +32,7 @@ type UnbondingWatcherMetrics struct {
 	FailedReportedActivateDelegations       prometheus.Counter
 	ReportedActivateDelegationsCounter      prometheus.Counter
 	NumberOfActivationInProgress            prometheus.Gauge
+	NumberOfVerifiedDelegations             prometheus.Gauge
 	MethodExecutionLatency                  *prometheus.HistogramVec
 }
 
@@ -85,6 +86,11 @@ func newUnbondingWatcherMetrics(registry *prometheus.Registry) *UnbondingWatcher
 			Namespace: "vigilante",
 			Name:      "unbonding_watcher_number_of_activation_in_progress",
 			Help:      "The number of activations in progress",
+		}),
+		NumberOfVerifiedDelegations: registerer.NewGauge(prometheus.GaugeOpts{
+			Namespace: "vigilante",
+			Name:      "unbonding_watcher_number_of_verified_delegations",
+			Help:      "The number of verified delegations",
 		}),
 	}
 


### PR DESCRIPTION
This should solve a long lock wait time, which happens when fetching delegations into the tracker and trying to update a tracker