### PR TITLE
chore: add semaphore to rate limit activations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#136](https://github.com/babylonlabs-io/vigilante/pull/136) rate limit activations
+
 ## v0.18.0
 
 ### Improvements


### PR DESCRIPTION
Adds rate limit to number of activation go routines to less the load on RPC