### PR TITLE
fix: panic in submitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#140](https://github.com/babylonlabs-io/vigilante/pull/140) fix panic in submitter
+
 ## v0.18.0
 
 ### Improvements

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -207,6 +207,7 @@ func (s *Submitter) processCheckpoints() {
 			if err := s.relayer.SendCheckpointToBTC(ckpt); err != nil {
 				s.logger.Errorf("Failed to submit the raw checkpoint for %v: %v", ckpt.Ckpt.EpochNum, err)
 				s.metrics.FailedCheckpointsCounter.Inc()
+				continue
 			}
 			if err := s.relayer.MaybeResubmitSecondCheckpointTx(ckpt); err != nil {
 				s.logger.Errorf("Failed to resubmit the raw checkpoint for %v: %v", ckpt.Ckpt.EpochNum, err)


### PR DESCRIPTION
[References](https://github.com/babylonlabs-io/vigilante/pull/138), for some reason docker CI fails for external PRs.

[Closes](https://github.com/babylonlabs-io/vigilante/issues/137)