### PR TITLE
CI: Bump pipelines to latest versions

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.11.2
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
      go-version: '1.23'
      go-lint-version: 'v1.60.2'
@@ -21,7 +21,7 @@ jobs:
        sudo apt-get install -y libzmq3-dev
 
   docker_pipeline:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
      publish: false

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   release:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_releaser.yml@v0.11.2
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.11.2
     with:
       go-version: '1.23'
       go-lint-version: 'v1.60.2'
@@ -25,7 +25,7 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.10.2
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.11.2
     secrets: inherit
     with:
       publish: true


### PR DESCRIPTION
version: https://github.com/babylonlabs-io/.github/blob/main/CHANGELOG.md#0112
Includes a fix for docker builds triggered by external contributor PRs.