### PR TITLE
chore: retry more when submitting headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#155](https://github.com/babylonlabs-io/vigilante/pull/155) chore: increase retry attempts for header reporter
+
 ## v0.19.0
 
 ### Bug Fixes

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -37,7 +37,7 @@ func (r *Reporter) getHeaderMsgsToSubmit(signer string, ibs []*types.IndexedBloc
 		err = retrywrap.Do(func() error {
 			res, err = r.babylonClient.ContainsBTCBlock(&blockHash)
 
-			return err
+			return fmt.Errorf("error in contains block: %w", err)
 		},
 			retry.Delay(r.retrySleepTime),
 			retry.MaxDelay(r.maxRetrySleepTime),
@@ -79,7 +79,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 	err := retrywrap.Do(func() error {
 		res, err := r.babylonClient.InsertHeaders(context.Background(), msg)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not submit headers: %w", err)
 		}
 		r.logger.Infof("Successfully submitted %d headers to Babylon with response code %v", len(msg.Headers), res.Code)
 
@@ -87,6 +87,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 	},
 		retry.Delay(r.retrySleepTime),
 		retry.MaxDelay(r.maxRetrySleepTime),
+		bootstrapAttemptsAtt,
 	)
 	if err != nil {
 		r.metrics.FailedHeadersCounter.Add(float64(len(msg.Headers)))

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -37,7 +37,7 @@ func (r *Reporter) getHeaderMsgsToSubmit(signer string, ibs []*types.IndexedBloc
 		err = retrywrap.Do(func() error {
 			res, err = r.babylonClient.ContainsBTCBlock(&blockHash)
 
-			return fmt.Errorf("error in contains block: %w", err)
+			return err
 		},
 			retry.Delay(r.retrySleepTime),
 			retry.MaxDelay(r.maxRetrySleepTime),


### PR DESCRIPTION
Increase the default retry amount from default 5 which we have in bbn client reliable send msg to 60