### PR TITLE
chore: retry more when submitting headers (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#154](https://github.com/babylonlabs-io/vigilante/pull/154) fix: panic in maybeResendSecondTxOfCheckpointToBTC
 
+### Improvements
+
+* [#155](https://github.com/babylonlabs-io/vigilante/pull/155) chore: increase retry attempts for header reporter
+
 ## v0.19.0
 
 ### Bug Fixes

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -79,7 +79,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 	err := retrywrap.Do(func() error {
 		res, err := r.babylonClient.InsertHeaders(context.Background(), msg)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not submit headers: %w", err)
 		}
 		r.logger.Infof("Successfully submitted %d headers to Babylon with response code %v", len(msg.Headers), res.Code)
 
@@ -87,6 +87,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 	},
 		retry.Delay(r.retrySleepTime),
 		retry.MaxDelay(r.maxRetrySleepTime),
+		bootstrapAttemptsAtt,
 	)
 	if err != nil {
 		r.metrics.FailedHeadersCounter.Add(float64(len(msg.Headers)))


### PR DESCRIPTION
Increase the default retry amount from default 5 which we have in bbn client reliable send msg to 60