### PR TITLE
chore: better buckets for method latency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#178](https://github.com/babylonlabs-io/vigilante/pull/178) chore: better bucket range
+
 ## v0.19.4
 
 ### Bug Fixes

--- a/metrics/btcstaking_tracker.go
+++ b/metrics/btcstaking_tracker.go
@@ -80,7 +80,7 @@ func newUnbondingWatcherMetrics(registry *prometheus.Registry) *UnbondingWatcher
 			Namespace: "vigilante",
 			Name:      "unbonding_watcher_method_latency_seconds",
 			Help:      "Latency in seconds",
-			Buckets:   []float64{.001, .002, .005, .01, .025, .05, .1},
+			Buckets:   []float64{0.3, 1, 2, 5, 10, 30, 60, 120, 180, 300},
 		}, []string{"method"}),
 		NumberOfActivationInProgress: registerer.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vigilante",


### PR DESCRIPTION
Our method executions aren't sub 1s, so we need to adjust