### PR TITLE
chore: lax unecessary btc tx checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#209](https://github.com/babylonlabs-io/vigilante/pull/209) fix: wait until slashing tx k-deep
 * [#223](https://github.com/babylonlabs-io/vigilante/pull/223) fix: consider minimal fee for bump
 * [#226](https://github.com/babylonlabs-io/vigilante/pull/226) fix: reselect inputs after adding manual output
+* [#229](https://github.com/babylonlabs-io/vigilante/pull/229) chore: lax unecessary btc tx checks
 
 ## v0.19.9
 


### PR DESCRIPTION
Regarding the comment: "Submitter will only re-attempt to submit the checkpoint once the
configured `PollingIntervalSeconds` has elapsed.", not relevant as rewards for checkpoint submitters will not be distributed in the near term.

closes #220, ref to BP2-021