### PR TITLE
chore: use file based lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#229](https://github.com/babylonlabs-io/vigilante/pull/229) chore: bigger batch size for fetching delegations
 * [#233](https://github.com/babylonlabs-io/vigilante/pull/233) chore: cleanup ckpt cache
+* [#235](https://github.com/babylonlabs-io/vigilante/pull/233) chore: use file based lock to allocate ports
 
 ### Bug Fixes
 

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Directory for storing lock files
+const lockDir = "/tmp/testutil_ports"
 
 // AllocateUniquePort tries to find an available TCP port on localhost
 // by testing multiple random ports within a specified range.
@@ -23,8 +24,6 @@ func AllocateUniquePort(t *testing.T) int {
 		basePort  = 20000
 		portRange = 30000
 	)
-
-	lockDir := t.TempDir()
 
 	// Ensure lock directory exists
 	if err := os.MkdirAll(lockDir, 0755); err != nil {

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -10,7 +10,6 @@ import (
 )
 
 // Directory for storing lock files
-const lockDir = "/tmp/testutil_ports"
 
 // AllocateUniquePort tries to find an available TCP port on localhost
 // by testing multiple random ports within a specified range.
@@ -24,6 +23,8 @@ func AllocateUniquePort(t *testing.T) int {
 		basePort  = 20000
 		portRange = 30000
 	)
+
+	lockDir := t.TempDir()
 
 	// Ensure lock directory exists
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
@@ -50,16 +51,13 @@ func AllocateUniquePort(t *testing.T) int {
 			continue // Port is already in use
 		}
 
-		// Close the listener to release the port
 		if err := listener.Close(); err != nil {
 			continue
 		}
 
-		// Successfully found an available port
 		return port
 	}
 
-	// If no available port was found, fail the test
 	t.Fatalf("failed to find an available port in range %d-%d", basePort, basePort+portRange)
 
 	return 0

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -4,17 +4,15 @@ import (
 	"fmt"
 	mrand "math/rand/v2"
 	"net"
-	"sync"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-// Track allocated ports, protected by a mutex
-var (
-	allocatedPorts = make(map[int]struct{})
-	portMutex      sync.Mutex
-)
+// Directory for storing lock files
+const lockDir = "/tmp/testutil_ports"
 
-// AllocateUniquePort tries to find an available TCP port on the localhost
+// AllocateUniquePort tries to find an available TCP port on localhost
 // by testing multiple random ports within a specified range.
 func AllocateUniquePort(t *testing.T) int {
 	randPort := func(base, spread int) int {
@@ -27,33 +25,37 @@ func AllocateUniquePort(t *testing.T) int {
 		portRange = 30000
 	)
 
+	// Ensure lock directory exists
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		t.Fatalf("failed to create lock directory: %v", err)
+	}
+
 	// Try up to 10 times to find an available port
 	for i := 0; i < 10; i++ {
 		port := randPort(basePort, portRange)
+		lockFile := filepath.Join(lockDir, fmt.Sprintf("%d.lock", port))
 
-		// Lock the mutex to check and modify the shared map
-		portMutex.Lock()
-		if _, exists := allocatedPorts[port]; exists {
-			// Port already allocated, try another one
-			portMutex.Unlock()
-
-			continue
+		// Try to create a lock file
+		lock, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			continue // Port is likely in use
 		}
+
+		// Ensure the file is removed if we fail to bind the port
+		defer lock.Close()
+		defer os.Remove(lockFile)
 
 		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err != nil {
-			portMutex.Unlock()
-
-			continue
+			continue // Port is already in use
 		}
 
-		allocatedPorts[port] = struct{}{}
-		portMutex.Unlock()
-
+		// Close the listener to release the port
 		if err := listener.Close(); err != nil {
 			continue
 		}
 
+		// Successfully found an available port
 		return port
 	}
 


### PR DESCRIPTION
we often have flaky tests due to mutex not properly working in the e2e for allocating port.

Trying to fix it with a file-based lock.

err that we often see:
```sh
API error (500): driver failed programming external connectivity on endpoint bitcoind-TestSlasher_SlashingUnbonding (5208fb0daff063a1ae7474082c19156de8b38fe74163adac195016b465db3f89): Error starting userland proxy: listen tcp4 0.0.0.0:35448: bind: address already in use
```