### PR TITLE
fix: send on closed chan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#223](https://github.com/babylonlabs-io/vigilante/pull/223) fix: consider minimal fee for bump
 * [#226](https://github.com/babylonlabs-io/vigilante/pull/226) fix: reselect inputs after adding manual output
 * [#229](https://github.com/babylonlabs-io/vigilante/pull/229) chore: lax unecessary btc tx checks
+* [#237](https://github.com/babylonlabs-io/vigilante/pull/237) fix: send on closed chan
 
 ## v0.19.9
 

--- a/btcstaking-tracker/atomicslasher/routines.go
+++ b/btcstaking-tracker/atomicslasher/routines.go
@@ -86,7 +86,11 @@ func (as *AtomicSlasher) slashingTxTracker() {
 				if trackedBTCDel != nil {
 					// this tx is slashing tx
 					slashingTxInfo := NewSlashingTxInfo(slashingPath, trackedBTCDel.StakingTxHash, tx)
-					as.slashingTxChan <- slashingTxInfo
+					select {
+					case as.slashingTxChan <- slashingTxInfo:
+					case <-as.quit: // prevent send on closed slashingTxChan
+						return
+					}
 				}
 			}
 		case <-as.quit:


### PR DESCRIPTION
often in e2e we see [err](https://github.com/babylonlabs-io/vigilante/actions/runs/13409769846/job/37457033675?pr=236):
```
goroutine 28015 [running]:
github.com/babylonlabs-io/vigilante/btcstaking-tracker/atomicslasher.(*AtomicSlasher).slashingTxTracker(0xc002e4ebe0)
	/home/runner/work/vigilante/vigilante/btcstaking-tracker/atomicslasher/routines.go:89 +0x7a9
created by github.com/babylonlabs-io/vigilante/btcstaking-tracker/atomicslasher.(*AtomicSlasher).Start.func1 in goroutine 28053
	/home/runner/work/vigilante/vigilante/btcstaking-tracker/atomicslasher/atomic_slasher.go:85 +0x89
FAIL	github.com/babylonlabs-io/vigilante/e2etest	197.720s
FAIL
```