### PR TITLE
fix: Reject non-negative value and Zero for time Interval used by time.ticker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#250](https://github.com/babylonlabs-io/vigilante/pull/250) fix: handle rpc errors in maybeResendFromStore
 * [#252](https://github.com/babylonlabs-io/vigilante/pull/252) fix: rbf compliant
+* [#258](https://github.com/babylonlabs-io/vigilante/pull/258) fix: Reject non-negative value and Zero for time Interval used by time.ticker
 
 ## v0.21.0
 

--- a/config/btcstaking_tracker.go
+++ b/config/btcstaking_tracker.go
@@ -45,22 +45,22 @@ func DefaultBTCStakingTrackerConfig() BTCStakingTrackerConfig {
 }
 
 func (cfg *BTCStakingTrackerConfig) Validate() error {
-	if cfg.CheckDelegationsInterval < 0 {
+	if cfg.CheckDelegationsInterval <= 0 {
 		return errors.New("check-delegations-interval can't be negative")
 	}
-	if cfg.CheckDelegationActiveInterval < 0 {
+	if cfg.CheckDelegationActiveInterval <= 0 {
 		return errors.New("check-if-delegation-active-interval can't be negative")
 	}
 
-	if cfg.FetchEvidenceInterval < 0 {
+	if cfg.FetchEvidenceInterval <= 0 {
 		return errors.New("fetch-evidence-interval can't be negative")
 	}
 
-	if cfg.RetrySubmitUnbondingTxInterval < 0 {
+	if cfg.RetrySubmitUnbondingTxInterval <= 0 {
 		return errors.New("retry-submit-unbonding-interval can't be negative")
 	}
 
-	if cfg.RetryJitter < 0 {
+	if cfg.RetryJitter <= 0 {
 		return errors.New("max-jitter-interval can't be negative")
 	}
 

--- a/config/common.go
+++ b/config/common.go
@@ -45,10 +45,10 @@ func (cfg *CommonConfig) Validate() error {
 	if !isOneOf(cfg.LogLevel, []string{"debug", "warn", "error", "panic", "fatal"}) {
 		return errors.New("log-level is not one of debug|warn|error|panic|fatal")
 	}
-	if cfg.RetrySleepTime < 0 {
+	if cfg.RetrySleepTime <= 0 {
 		return errors.New("retry-sleep-time can't be negative")
 	}
-	if cfg.MaxRetrySleepTime < 0 {
+	if cfg.MaxRetrySleepTime <= 0 {
 		return errors.New("max-retry-sleep-time can't be negative")
 	}
 


### PR DESCRIPTION
https://github.com/golang/go/blob/644b984027d11d43881507a938b28ed9df3b3320/src/time/tick.go#L37

in time.ticker, if checks if time.Interval is less than or equal with 0.

but vigilante doesn't check it and if I set to 0, it throws error.

<img width="1196" alt="screenshot" src="https://github.com/user-attachments/assets/c2a6d752-f8da-43ea-af92-1214f25e9b06" />