### PR TITLE
chore: Add fetch-evidence-interval to sample config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#255](https://github.com/babylonlabs-io/vigilante/pull/255) chore: disable tls in config
 * [#257](https://github.com/babylonlabs-io/vigilante/pull/257) chore: change default max
+* [#260](https://github.com/babylonlabs-io/vigilante/pull/260) chore: add fetch-evidence-interval to sample config
 
 ### Bug Fixes
 

--- a/sample-vigilante.yml
+++ b/sample-vigilante.yml
@@ -91,4 +91,5 @@ btcstaking-tracker:
   max-jitter-interval: 30s
   btcnetparams: simnet
   indexer-addr: localhost:3000
+  fetch-evidence-interval: 60
 


### PR DESCRIPTION
Also, seeing the sample-vigilante-docker.yml is out of sync