### PR TITLE
chore: additional check for getFundingtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#289](https://github.com/babylonlabs-io/vigilante/pull/289) chore: additional check for getFundingtx
+
 ## v0.22.1
 
 ### Bug Fixes

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -852,6 +852,10 @@ func (sew *StakingEventWatcher) latency(method string) func() {
 }
 
 func (sew *StakingEventWatcher) getFundingTxs(tx *wire.MsgTx) ([][]byte, error) {
+	if len(tx.TxIn) == 0 {
+		return nil, fmt.Errorf("no inputs in tx %s", tx.TxHash())
+	}
+
 	var fundingTxs [][]byte
 	for _, txIn := range tx.TxIn {
 		rawTransaction, err := sew.btcClient.GetRawTransaction(&txIn.PreviousOutPoint.Hash)
@@ -865,6 +869,10 @@ func (sew *StakingEventWatcher) getFundingTxs(tx *wire.MsgTx) ([][]byte, error) 
 		}
 
 		fundingTxs = append(fundingTxs, serializedTx)
+	}
+
+	if len(fundingTxs) == 0 {
+		return nil, fmt.Errorf("no funding txs found for tx %s", tx.TxHash())
 	}
 
 	return fundingTxs, nil


### PR DESCRIPTION
We got an odd error in this [issue](https://github.com/babylonlabs-io/vigilante/issues/288). 

The only way we would try submitting unbonding txn without funding txns would be if `getFundingTxs` returned empty slice. We add additional checks and errors for this. 

Inspecting the txn `70647aec15bfd4689b1f1a630f55b5abdab9e03980ed139cd851873652f565ec` points out that it does have inputs, so the function should have returned a non nil slice.