### PR TITLE
chore: version cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#294](https://github.com/babylonlabs-io/vigilante/pull/294) chore: version cmd
+
 ## v0.23.0
 
 ### Improvements

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ BUILDDIR ?= $(CURDIR)/build
 BABYLON_PKG := github.com/babylonlabs-io/babylon/cmd/babylond
 
 GO_BIN := ${GOPATH}/bin
+VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 
-ldflags := $(LDFLAGS)
+ldflags := $(LDFLAGS) -X github.com/babylonlabs-io/vigilante/version.version=$(VERSION)
 build_tags := $(BUILD_TAGS)
 build_args := $(BUILD_ARGS)
 

--- a/cmd/vigilante/cmd/root.go
+++ b/cmd/vigilante/cmd/root.go
@@ -15,6 +15,7 @@ func NewRootCmd() *cobra.Command {
 		GetMonitorCmd(),
 		GetBTCStakingTracker(),
 		CommandDumpConfig(),
+		CommandVersion(),
 	)
 
 	return rootCmd

--- a/cmd/vigilante/cmd/version.go
+++ b/cmd/vigilante/cmd/version.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/babylonlabs-io/vigilante/version"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// CommandVersion prints version of the binary
+func CommandVersion() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "version",
+		Short:   "Prints version of this binary.",
+		Aliases: []string{"v"},
+		Example: "vigilante version",
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			v := version.Version()
+			commit, ts := version.CommitInfo()
+			if v == "" {
+				v = "main"
+			}
+
+			var sb strings.Builder
+			_, _ = sb.WriteString("Version:       " + v)
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Commit:    " + commit)
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Timestamp: " + ts)
+			_, _ = sb.WriteString("\n")
+
+			cmd.Printf(sb.String()) //nolint:govet // it's not an issue
+		},
+	}
+
+	return cmd
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"runtime/debug"
+)
+
+// version set at build-time
+var version = "main"
+
+func CommitInfo() (string, string) {
+	hash, timestamp := "unknown", "unknown"
+	hashLen := 7
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return hash, timestamp
+	}
+
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			if len(s.Value) < hashLen {
+				hashLen = len(s.Value)
+			}
+			hash = s.Value[:hashLen]
+		} else if s.Key == "vcs.time" {
+			timestamp = s.Value
+		}
+	}
+
+	return hash, timestamp
+}
+
+// Version returns the version
+func Version() string {
+	return version
+}


### PR DESCRIPTION
adds command `vigilante version`:

```
Version:       main
Git Commit:    8f37f70
Git Timestamp: 2025-03-29T14:45:14Z
```