### PR TITLE
chore: tm retry container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#294](https://github.com/babylonlabs-io/vigilante/pull/294) chore: version cmd
 * [#258](https://github.com/babylonlabs-io/vigilante/pull/258) fix: Reject non-negative value and Zero for time Interval used by time.ticker
+* [#296](https://github.com/babylonlabs-io/vigilante/pull/296) chore: tm retry container start
 
 ## v0.23.0
 

--- a/e2etest/bitcoind_node_setup.go
+++ b/e2etest/bitcoind_node_setup.go
@@ -121,3 +121,7 @@ func (h *BitcoindTestHandler) ImportDescriptors(descriptor string) {
 func (h *BitcoindTestHandler) Stop() {
 	_ = h.m.ClearResources()
 }
+
+func (h *BitcoindTestHandler) Remove(name string) error {
+	return h.m.ClearResource(name)
+}

--- a/e2etest/bitcoind_node_setup.go
+++ b/e2etest/bitcoind_node_setup.go
@@ -41,7 +41,7 @@ func NewBitcoindHandler(t *testing.T, manager *container.Manager) *BitcoindTestH
 	}
 }
 
-func (h *BitcoindTestHandler) Start(t *testing.T) (*dockertest.Resource, string) {
+func (h *BitcoindTestHandler) Start(t *testing.T) (*dockertest.Resource, string, error) {
 	tempPath, err := os.MkdirTemp("", "vigilante-test-*")
 	require.NoError(h.t, err)
 
@@ -50,7 +50,9 @@ func (h *BitcoindTestHandler) Start(t *testing.T) (*dockertest.Resource, string)
 	})
 
 	bitcoinResource, err := h.m.RunBitcoindResource(t, tempPath)
-	require.NoError(h.t, err)
+	if err != nil {
+		return nil, "", err
+	}
 
 	h.t.Cleanup(func() {
 		_ = h.m.ClearResources()
@@ -64,7 +66,7 @@ func (h *BitcoindTestHandler) Start(t *testing.T) (*dockertest.Resource, string)
 		return err == nil
 	}, startTimeout, 500*time.Millisecond, "bitcoind did not start")
 
-	return bitcoinResource, tempPath
+	return bitcoinResource, tempPath, nil
 }
 
 // GetBlockCount retrieves the current number of blocks in the blockchain from the Bitcoind.

--- a/e2etest/bitcoind_node_setup.go
+++ b/e2etest/bitcoind_node_setup.go
@@ -123,5 +123,5 @@ func (h *BitcoindTestHandler) Stop() {
 }
 
 func (h *BitcoindTestHandler) Remove(name string) error {
-	return h.m.ClearResource(name)
+	return h.m.RemoveContainer(name)
 }

--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -9,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -299,18 +298,8 @@ func (m *Manager) ClearResources() error {
 	return nil
 }
 
-func (m *Manager) ClearResource(name string) error {
-	for _, resource := range m.resources {
-		if strings.Contains(resource.Container.Name, name) {
-			if err := m.pool.Purge(resource); err != nil {
-				return err
-			}
-
-			break
-		}
-	}
-
-	return nil
+func (m *Manager) RemoveContainer(name string) error {
+	return m.pool.RemoveContainerByName(name)
 }
 
 func noRestart(config *docker.HostConfig) {

--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -292,6 +293,20 @@ func (m *Manager) ClearResources() error {
 	for _, resource := range m.resources {
 		if err := m.pool.Purge(resource); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) ClearResource(name string) error {
+	for _, resource := range m.resources {
+		if strings.Contains(resource.Container.Name, name) {
+			if err := m.pool.Purge(resource); err != nil {
+				return err
+			}
+
+			break
 		}
 	}
 

--- a/e2etest/electrs_setup.go
+++ b/e2etest/electrs_setup.go
@@ -24,9 +24,11 @@ func NewElectrsHandler(t *testing.T, manager *container.Manager) *ElectrsTestHan
 	}
 }
 
-func (h *ElectrsTestHandler) Start(t *testing.T, bitcoindPath, btcRpcAddr string) *dockertest.Resource {
+func (h *ElectrsTestHandler) Start(t *testing.T, bitcoindPath, btcRpcAddr string) (*dockertest.Resource, error) {
 	resource, err := h.m.RunElectrsResource(t, t.TempDir(), bitcoindPath, btcRpcAddr)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 
 	url := fmt.Sprintf("http://localhost:%s", resource.GetPort("3000/tcp"))
 
@@ -36,7 +38,7 @@ func (h *ElectrsTestHandler) Start(t *testing.T, bitcoindPath, btcRpcAddr string
 		return err == nil
 	}, startTimeout, 500*time.Millisecond, "electrs did not start")
 
-	return resource
+	return resource, nil
 }
 
 func (h *ElectrsTestHandler) GetTipHeight(url string) (int, error) {

--- a/e2etest/electrs_setup.go
+++ b/e2etest/electrs_setup.go
@@ -56,7 +56,7 @@ func (h *ElectrsTestHandler) GetTipHeight(url string) (int, error) {
 }
 
 func (h *ElectrsTestHandler) Remove(name string) error {
-	return h.m.ClearResource(name)
+	return h.m.RemoveContainer(name)
 }
 
 func fetch(url string) (string, error) {

--- a/e2etest/electrs_setup.go
+++ b/e2etest/electrs_setup.go
@@ -55,6 +55,10 @@ func (h *ElectrsTestHandler) GetTipHeight(url string) (int, error) {
 	return height, nil
 }
 
+func (h *ElectrsTestHandler) Remove(name string) error {
+	return h.m.ClearResource(name)
+}
+
 func fetch(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -101,7 +101,7 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 			require.NoError(t, errResource)
 		}
 		return err == nil
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 25*time.Second, 500*time.Millisecond)
 
 	passphrase := "pass"
 	_ = btcHandler.CreateWallet("default", passphrase)
@@ -117,7 +117,7 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 			require.NoError(t, errResource)
 		}
 		return err == nil
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 25*time.Second, 500*time.Millisecond)
 
 	cfg := defaultVigilanteConfig()
 	cfg.BTCStakingTracker.IndexerAddr = fmt.Sprintf("http://localhost:%s", electrs.GetPort("3000/tcp"))
@@ -168,7 +168,7 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 			require.NoError(t, errResource)
 		}
 		return err == nil
-	}, 5*time.Second, 500*time.Millisecond)
+	}, 25*time.Second, 500*time.Millisecond)
 
 	// create Babylon client
 	cfg.Babylon.KeyDirectory = filepath.Join(tmpDir, "node0", "babylond")

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/babylonlabs-io/babylon/client/babylonclient"
 	"github.com/babylonlabs-io/vigilante/e2etest/container"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/ory/dockertest/v3"
 	"go.uber.org/zap"
 	"os"
 	"path/filepath"
@@ -90,17 +91,32 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	require.NoError(t, err)
 
 	btcHandler := NewBitcoindHandler(t, manager)
-	bitcoind, bitcoindPath := btcHandler.Start(t)
+	var bitcoind *dockertest.Resource
+	var bitcoindPath string
+	require.Eventually(t, func() bool {
+		bitcoind, bitcoindPath, err = btcHandler.Start(t)
+		if err != nil {
+			t.Logf("failed to start bitcoind: %v", err)
+		}
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
+
 	passphrase := "pass"
 	_ = btcHandler.CreateWallet("default", passphrase)
 
 	internalBtcRpc := fmt.Sprintf("%s:18443", bitcoind.Container.NetworkSettings.IPAddress)
 	electrsHandler := NewElectrsHandler(t, manager)
-	electrs := electrsHandler.Start(t, bitcoindPath, internalBtcRpc)
+	var electrs *dockertest.Resource
+	require.Eventually(t, func() bool {
+		electrs, err = electrsHandler.Start(t, bitcoindPath, internalBtcRpc)
+		if err != nil {
+			t.Logf("failed to start electrs: %v", err)
+		}
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	cfg := defaultVigilanteConfig()
 	cfg.BTCStakingTracker.IndexerAddr = fmt.Sprintf("http://localhost:%s", electrs.GetPort("3000/tcp"))
-
 	cfg.BTC.Endpoint = fmt.Sprintf("127.0.0.1:%s", bitcoind.GetPort("18443/tcp"))
 
 	testRpcClient, err := rpcclient.New(&rpcclient.ConnConfig{
@@ -139,8 +155,14 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	tmpDir, err := tempDir(t)
 	require.NoError(t, err)
 
-	babylond, err := manager.RunBabylondResource(t, tmpDir, baseHeaderHex, hex.EncodeToString(pkScript), epochInterval)
-	require.NoError(t, err)
+	var babylond *dockertest.Resource
+	require.Eventually(t, func() bool {
+		babylond, err = manager.RunBabylondResource(t, tmpDir, baseHeaderHex, hex.EncodeToString(pkScript), epochInterval)
+		if err != nil {
+			t.Logf("failed to start babylond: %v", err)
+		}
+		return err == nil
+	}, 5*time.Second, 500*time.Millisecond)
 
 	// create Babylon client
 	cfg.Babylon.KeyDirectory = filepath.Join(tmpDir, "node0", "babylond")

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -97,6 +97,8 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 		bitcoind, bitcoindPath, err = btcHandler.Start(t)
 		if err != nil {
 			t.Logf("failed to start bitcoind: %v", err)
+			errResource := btcHandler.Remove(fmt.Sprintf("bitcoind-%s", t.Name()))
+			require.NoError(t, errResource)
 		}
 		return err == nil
 	}, 5*time.Second, 500*time.Millisecond)
@@ -111,6 +113,8 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 		electrs, err = electrsHandler.Start(t, bitcoindPath, internalBtcRpc)
 		if err != nil {
 			t.Logf("failed to start electrs: %v", err)
+			errResource := electrsHandler.Remove(fmt.Sprintf("electrs-%s", t.Name()))
+			require.NoError(t, errResource)
 		}
 		return err == nil
 	}, 5*time.Second, 500*time.Millisecond)
@@ -160,6 +164,8 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 		babylond, err = manager.RunBabylondResource(t, tmpDir, baseHeaderHex, hex.EncodeToString(pkScript), epochInterval)
 		if err != nil {
 			t.Logf("failed to start babylond: %v", err)
+			errResource := manager.ClearResource(fmt.Sprintf("babylond-%s", t.Name()))
+			require.NoError(t, errResource)
 		}
 		return err == nil
 	}, 5*time.Second, 500*time.Millisecond)

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -102,7 +102,7 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 		}
 		return err == nil
 	}, 25*time.Second, 500*time.Millisecond)
-
+	
 	passphrase := "pass"
 	_ = btcHandler.CreateWallet("default", passphrase)
 
@@ -163,8 +163,8 @@ func StartManager(t *testing.T, numMatureOutputsInWallet uint32, epochInterval u
 	require.Eventually(t, func() bool {
 		babylond, err = manager.RunBabylondResource(t, tmpDir, baseHeaderHex, hex.EncodeToString(pkScript), epochInterval)
 		if err != nil {
-			t.Logf("failed to start babylond: %v", err)
-			errResource := manager.ClearResource(fmt.Sprintf("babylond-%s", t.Name()))
+			t.Logf("failed to start babylond, test: %s err: %v", t.Name(), err)
+			errResource := manager.RemoveContainer(fmt.Sprintf("babylond-%s", t.Name()))
 			require.NoError(t, errResource)
 		}
 		return err == nil


### PR DESCRIPTION
As we still get conflicts on ports somehow 🤷, we introduce retries to start the container. 

```
test_manager.go:143: 
[539](https://github.com/babylonlabs-io/vigilante/actions/runs/14154681891/job/39652388908?pr=295#step:7:540)
        	Error Trace:	/home/runner/work/vigilante/vigilante/e2etest/test_manager.go:143
[540](https://github.com/babylonlabs-io/vigilante/actions/runs/14154681891/job/39652388908?pr=295#step:7:541)
        	            				/home/runner/work/vigilante/vigilante/e2etest/reporter_e2e_test.go:259
[541](https://github.com/babylonlabs-io/vigilante/actions/runs/14154681891/job/39652388908?pr=295#step:7:542)
        	Error:      	Received unexpected error:
[542](https://github.com/babylonlabs-io/vigilante/actions/runs/14154681891/job/39652388908?pr=295#step:7:543)
        	            	API error (500): driver failed programming external connectivity on endpoint babylond-TestReporter_Censorship (4d382b3ffa9e56e14402a5808249287453f1f08b8a2b8055d6fec51811042b84): Error starting userland proxy: listen tcp4 0.0.0.0:37766: bind: address already in use
```