### PR TITLE
chore: bootstrap only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#327](https://github.com/babylonlabs-io/vigilante/pull/327) chore: bootstrap only once
+
 ## v0.23.3
 
 ### Bug Fixes

--- a/reporter/bootstrapping.go
+++ b/reporter/bootstrapping.go
@@ -66,6 +66,28 @@ func (r *Reporter) bootstrap() error {
 		err                  error
 	)
 
+	r.bootstrapMutex.Lock()
+	if r.bootstrapInProgress {
+		r.bootstrapMutex.Unlock()
+		// we only allow one bootstrap process at a time
+		return fmt.Errorf("bootstrap already in progress")
+	}
+	r.bootstrapInProgress = true
+	r.bootstrapWg.Add(1)
+	r.bootstrapMutex.Unlock()
+
+	// flag to indicate if we should clean up, err happened
+	success := false
+	defer func() {
+		// cleanup func in case we error, prevents deadlocks
+		if !success {
+			r.bootstrapMutex.Lock()
+			r.bootstrapInProgress = false
+			r.bootstrapMutex.Unlock()
+			r.bootstrapWg.Done()
+		}
+	}()
+
 	// ensure BTC has caught up with BBN header chain
 	if err := r.waitUntilBTCSync(); err != nil {
 		return err
@@ -89,14 +111,14 @@ func (r *Reporter) bootstrap() error {
 
 	signer := r.babylonClient.MustGetAddr()
 
-	r.logger.Infof("BTC height: %d. BTCLightclient height: %d. Start syncing from height %d.", btcLatestBlockHeight, consistencyInfo.bbnLatestBlockHeight, consistencyInfo.startSyncHeight)
+	r.logger.Infof("BTC height: %d. BTCLightclient height: %d. Start syncing from height %d.",
+		btcLatestBlockHeight, consistencyInfo.bbnLatestBlockHeight, consistencyInfo.startSyncHeight)
 
 	// extracts and submits headers for each block in ibs
 	// Note: As we are retrieving blocks from btc cache from block just after confirmed block which
 	// we already checked for consistency, we can be sure that even if rest of the block headers is different than in Babylon
 	// due to reorg, our fork will be better than the one in Babylon.
-	_, err = r.ProcessHeaders(signer, ibs)
-	if err != nil {
+	if _, err = r.ProcessHeaders(signer, ibs); err != nil {
 		// this can happen when there are two contentious vigilantes or if our btc node is behind.
 		r.logger.Errorf("Failed to submit headers: %v", err)
 		// returning error as it is up to the caller to decide what do next
@@ -116,10 +138,19 @@ func (r *Reporter) bootstrap() error {
 	// fetch k+w blocks from cache and submit checkpoints
 	ibs = r.btcCache.GetAllBlocks()
 	go func() {
+		defer func() {
+			r.bootstrapMutex.Lock()
+			r.bootstrapInProgress = false
+			r.bootstrapMutex.Unlock()
+			r.bootstrapWg.Done()
+		}()
+		r.logger.Infof("Async processing checkpoints started")
 		_, _ = r.ProcessCheckpoints(signer, ibs)
 	}()
 
 	r.logger.Info("Successfully finished bootstrapping")
+
+	success = true
 
 	return nil
 }
@@ -147,6 +178,8 @@ func (r *Reporter) bootstrapWithRetries() {
 	ctx, cancel := r.reporterQuitCtx()
 	defer cancel()
 	if err := retry.Do(func() error {
+		r.bootstrapWg.Wait()
+
 		return r.bootstrap()
 	},
 		retry.Context(ctx),

--- a/reporter/bootstrapping.go
+++ b/reporter/bootstrapping.go
@@ -178,6 +178,8 @@ func (r *Reporter) bootstrapWithRetries() {
 	ctx, cancel := r.reporterQuitCtx()
 	defer cancel()
 	if err := retry.Do(func() error {
+		// we don't want to allow concurrent bootstrap process, if bootstrap is already in progress
+		// we should wait for it to finish
 		r.bootstrapWg.Wait()
 
 		return r.bootstrap()
@@ -210,7 +212,7 @@ func (r *Reporter) initBTCCache() error {
 		ibs                  []*types.IndexedBlock
 	)
 
-	r.btcCache, err = types.NewBTCCache(r.Cfg.BTCCacheSize) // TODO: give an option to be unsized
+	r.btcCache, err = types.NewBTCCache(r.cfg.BTCCacheSize) // TODO: give an option to be unsized
 	if err != nil {
 		panic(err)
 	}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -43,6 +43,10 @@ type Reporter struct {
 	started                       bool
 	quit                          chan struct{}
 	quitMu                        sync.Mutex
+
+	bootstrapMutex      sync.Mutex
+	bootstrapInProgress bool
+	bootstrapWg         sync.WaitGroup
 }
 
 func New(

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Reporter struct {
-	Cfg    *config.ReporterConfig
+	cfg    *config.ReporterConfig
 	logger *zap.SugaredLogger
 
 	btcClient     btcclient.BTCClient
@@ -34,7 +34,7 @@ type Reporter struct {
 	maxRetryTimes     uint
 
 	// Internal states of the reporter
-	CheckpointCache               *types.CheckpointCache
+	checkpointCache               *types.CheckpointCache
 	btcCache                      *types.BTCCache
 	btcConfirmationDepth          uint32
 	checkpointFinalizationTimeout uint32
@@ -46,7 +46,10 @@ type Reporter struct {
 
 	bootstrapMutex      sync.Mutex
 	bootstrapInProgress bool
-	bootstrapWg         sync.WaitGroup
+	// bootstrapWg is used to wait for the bootstrap process to finish
+	// bootstrapWg is incremented in bootstrap()
+	// bootstrapWg is waited in bootstrapWithRetries()
+	bootstrapWg sync.WaitGroup
 }
 
 func New(
@@ -90,7 +93,7 @@ func New(
 	ckptCache := types.NewCheckpointCache(checkpointTag, btctxformatter.CurrentVersion)
 
 	return &Reporter{
-		Cfg:                           cfg,
+		cfg:                           cfg,
 		logger:                        logger,
 		retrySleepTime:                retrySleepTime,
 		maxRetrySleepTime:             maxRetrySleepTime,
@@ -98,7 +101,7 @@ func New(
 		btcClient:                     btcClient,
 		babylonClient:                 babylonClient,
 		btcNotifier:                   btcNotifier,
-		CheckpointCache:               ckptCache,
+		checkpointCache:               ckptCache,
 		btcConfirmationDepth:          k,
 		checkpointFinalizationTimeout: w,
 		metrics:                       metrics,
@@ -146,7 +149,7 @@ func (r *Reporter) Start() {
 	r.wg.Add(1)
 	go r.blockEventHandler(blockNotifier)
 
-	go r.CheckpointCache.StartCleanupRoutine(r.quit, time.Hour, 24*time.Hour)
+	go r.checkpointCache.StartCleanupRoutine(r.quit, time.Hour, 24*time.Hour)
 
 	// start record time-related metrics
 	r.metrics.RecordMetrics()

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -65,7 +65,7 @@ func (r *Reporter) getHeaderMsgsToSubmit(signer string, ibs []*types.IndexedBloc
 	// wrap the headers to MsgInsertHeaders msgs from the subset of indexed blocks
 	ibsToSubmit = ibs[startPoint:]
 
-	blockChunks := chunkBy(ibsToSubmit, int(r.Cfg.MaxHeadersInMsg))
+	blockChunks := chunkBy(ibsToSubmit, int(r.cfg.MaxHeadersInMsg))
 
 	headerMsgsToSubmit := make([]*btclctypes.MsgInsertHeaders, 0, len(blockChunks))
 
@@ -87,7 +87,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 				context.Background(),
 				msg,
 				[]*coserrors.Error{btclctypes.ErrForkStartWithKnownHeader}, // expected
-				nil,                                                        // abort errors
+				nil, // abort errors
 			)
 			if err != nil {
 				return fmt.Errorf("could not submit headers: %w", err)
@@ -238,10 +238,10 @@ func (r *Reporter) extractCheckpoints(ib *types.IndexedBlock) int {
 		}
 
 		// cache the segment to ckptCache
-		ckptSeg := types.NewCkptSegment(r.CheckpointCache.Tag, r.CheckpointCache.Version, ib, tx)
+		ckptSeg := types.NewCkptSegment(r.checkpointCache.Tag, r.checkpointCache.Version, ib, tx)
 		if ckptSeg != nil {
 			r.logger.Infof("Found a checkpoint segment in tx %v with index %d: %v", tx.Hash(), ckptSeg.Index, ckptSeg.Data)
-			if err := r.CheckpointCache.AddSegment(ckptSeg); err != nil {
+			if err := r.checkpointCache.AddSegment(ckptSeg); err != nil {
 				r.logger.Errorf("Failed to add the ckpt segment in tx %v to the ckptCache: %v", tx.Hash(), err)
 
 				continue
@@ -261,8 +261,8 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 
 	// get matched ckpt parts from the ckptCache
 	// Note that Match() has ensured the checkpoints are always ordered by epoch number
-	r.CheckpointCache.Match()
-	numMatchedCkpts := r.CheckpointCache.NumCheckpoints()
+	r.checkpointCache.Match()
+	numMatchedCkpts := r.checkpointCache.NumCheckpoints()
 
 	if numMatchedCkpts == 0 {
 		r.logger.Debug("Found no matched pair of checkpoint segments in this match attempt")
@@ -275,7 +275,7 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 	for {
 		// pop the earliest checkpoint
 		// if popping a nil checkpoint, then all checkpoints are popped, break the for loop
-		ckpt := r.CheckpointCache.PopEarliestCheckpoint()
+		ckpt := r.checkpointCache.PopEarliestCheckpoint()
 		if ckpt == nil {
 			break
 		}

--- a/types/ckpt_cache.go
+++ b/types/ckpt_cache.go
@@ -96,6 +96,8 @@ func (c *CheckpointCache) Match() {
 
 func (c *CheckpointCache) PopEarliestCheckpoint() *Ckpt {
 	if c.HasCheckpoints() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		ckpt := c.Checkpoints[0]
 		c.Checkpoints = c.Checkpoints[1:]
 

--- a/types/ckpt_cache.go
+++ b/types/ckpt_cache.go
@@ -95,9 +95,10 @@ func (c *CheckpointCache) Match() {
 }
 
 func (c *CheckpointCache) PopEarliestCheckpoint() *Ckpt {
-	if c.HasCheckpoints() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.Checkpoints) > 0 {
 		ckpt := c.Checkpoints[0]
 		c.Checkpoints = c.Checkpoints[1:]
 
@@ -124,10 +125,6 @@ func (c *CheckpointCache) NumCheckpoints() int {
 	defer c.mu.Unlock()
 
 	return len(c.Checkpoints)
-}
-
-func (c *CheckpointCache) HasCheckpoints() bool {
-	return c.NumCheckpoints() > 0
 }
 
 func (c *CheckpointCache) StartCleanupRoutine(stopChan chan struct{}, cleanupInterval time.Duration, segmentTTL time.Duration) {


### PR DESCRIPTION
Make sure we don't have concurrent calls to bootstrap until we finish with async handling for the call to ProcessCheckpoints