### PR TITLE
fix: Prevent reporter retry loop on ErrForkStartWithKnownHeader (#330) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#330](https://github.com/babylonlabs-io/vigilante/pull/330) fix: Prevent reporter retry loop on ErrForkStartWithKnownHeader
+
 ## v0.23.4
 
 ### Improvements

--- a/e2etest/reporter_e2e_test.go
+++ b/e2etest/reporter_e2e_test.go
@@ -413,6 +413,6 @@ func TestReporter_DuplicateSubmissions(t *testing.T) {
 
 	// we expect that we have failed headers
 	require.Eventually(t, func() bool {
-		return promtestutil.ToFloat64(reporterMetrics.FailedHeadersCounter) > 0 || promtestutil.ToFloat64(reporter2Metrics.FailedHeadersCounter) > 0
+		return promtestutil.ToFloat64(reporterMetrics.FailedHeadersCounter) == 0 || promtestutil.ToFloat64(reporter2Metrics.FailedHeadersCounter) == 0
 	}, longEventuallyWaitTimeOut, eventuallyPollTime)
 }

--- a/reporter/expected_babylon_client.go
+++ b/reporter/expected_babylon_client.go
@@ -2,7 +2,9 @@ package reporter
 
 import (
 	"context"
+	"cosmossdk.io/errors"
 	"github.com/babylonlabs-io/babylon/client/babylonclient"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/babylonlabs-io/babylon/client/config"
 	btcctypes "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
@@ -19,5 +21,6 @@ type BabylonClient interface {
 	BTCHeaderChainTip() (*btclctypes.QueryTipResponse, error)
 	BTCBaseHeader() (*btclctypes.QueryBaseHeaderResponse, error)
 	InsertBTCSpvProof(ctx context.Context, msg *btcctypes.MsgInsertBTCSpvProof) (*babylonclient.RelayerTxResponse, error)
+	ReliablySendMsg(ctx context.Context, msg sdk.Msg, expectedErrors []*errors.Error, unrecoverableErrors []*errors.Error) (*babylonclient.RelayerTxResponse, error)
 	Stop() error
 }

--- a/reporter/mock_babylon_client.go
+++ b/reporter/mock_babylon_client.go
@@ -8,11 +8,13 @@ import (
 	context "context"
 	reflect "reflect"
 
+	errors "cosmossdk.io/errors"
 	babylonclient "github.com/babylonlabs-io/babylon/client/babylonclient"
 	config "github.com/babylonlabs-io/babylon/client/config"
 	types "github.com/babylonlabs-io/babylon/x/btccheckpoint/types"
 	types0 "github.com/babylonlabs-io/babylon/x/btclightclient/types"
 	chainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
+	types1 "github.com/cosmos/cosmos-sdk/types"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -155,6 +157,21 @@ func (m *MockBabylonClient) MustGetAddr() string {
 func (mr *MockBabylonClientMockRecorder) MustGetAddr() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustGetAddr", reflect.TypeOf((*MockBabylonClient)(nil).MustGetAddr))
+}
+
+// ReliablySendMsg mocks base method.
+func (m *MockBabylonClient) ReliablySendMsg(ctx context.Context, msg types1.Msg, expectedErrors, unrecoverableErrors []*errors.Error) (*babylonclient.RelayerTxResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReliablySendMsg", ctx, msg, expectedErrors, unrecoverableErrors)
+	ret0, _ := ret[0].(*babylonclient.RelayerTxResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReliablySendMsg indicates an expected call of ReliablySendMsg.
+func (mr *MockBabylonClientMockRecorder) ReliablySendMsg(ctx, msg, expectedErrors, unrecoverableErrors interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReliablySendMsg", reflect.TypeOf((*MockBabylonClient)(nil).ReliablySendMsg), ctx, msg, expectedErrors, unrecoverableErrors)
 }
 
 // Stop mocks base method.

--- a/reporter/utils_test.go
+++ b/reporter/utils_test.go
@@ -80,7 +80,7 @@ func FuzzProcessHeaders(f *testing.F) {
 			&btclctypes.QueryContainsBytesResponse{Contains: false}, nil).AnyTimes()
 
 		// inserting header will always be successful
-		mockBabylonClient.EXPECT().InsertHeaders(gomock.Any(), gomock.Any()).Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).AnyTimes()
+		mockBabylonClient.EXPECT().ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).AnyTimes()
 
 		// if Babylon client contains this block, numSubmitted has to be 0, otherwise 1
 		numSubmitted, err := mockReporter.ProcessHeaders("", ibs)
@@ -103,7 +103,7 @@ func FuzzProcessCheckpoints(f *testing.F) {
 
 		mockBabylonClient, mockReporter := newMockReporter(t, ctrl)
 		// inserting SPV proofs is always successful
-		mockBabylonClient.EXPECT().InsertBTCSpvProof(gomock.Any(), gomock.Any()).Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).AnyTimes()
+		mockBabylonClient.EXPECT().ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).AnyTimes()
 
 		// generate a random number of blocks, with or without Babylon txs
 		numBlocks := datagen.RandomInt(r, 100)

--- a/retrywrap/retry.go
+++ b/retrywrap/retry.go
@@ -18,6 +18,7 @@ var unrecoverableErrors = []error{
 	btcctypes.ErrNoCheckpointsForPreviousEpoch,
 	btcctypes.ErrInvalidCheckpointProof,
 	checkpointingtypes.ErrBlsPrivKeyDoesNotExist,
+	btclctypes.ErrForkStartWithKnownHeader,
 }
 
 // expectedErrors is a list of errors which can safely be ignored and should not be retried.


### PR DESCRIPTION
### Related Issue
- https://github.com/babylonlabs-io/vigilante/issues/329
- https://github.com/babylonlabs-io/vigilante/issues/322


### Summary
This PR resolves an issue where reporters repeatedly attempt to submit headers that have already been committed, resulting in prolonged retry cycles and unnecessary resource consumption.

This behavior occurred because submitHeaderMsgs() was designed to detect btclctypes.ErrForkStartWithKnownHeader using errors.Is(), but the error was often wrapped, causing the check to fail. In addition, the retry logic in both retrywrap.Do() and InsertHeaders() did not classify this error as expected, leading to redundant retries.


### Changes
Replace InsertHeaders with ReliablySendMsg

Uses expectedErrors to explicitly classify
btclctypes.ErrForkStartWithKnownHeader as a known, non-fatal error.

Prevents redundant retries at the client level.

Handle res == nil explicitly

Interprets this result as an expected error.

Logs and returns```btclctypes.ErrForkStartWithKnownHeader``` to allow upper layers to handle it gracefully.

Add ```btclctypes.ErrForkStartWithKnownHeader``` to retrywrap expected errors

Ensures that retrywrap does not attempt unnecessary retries or escalate the error.


### Example
Before:
```
Failed to submit headers: fork start with known header
Retrying in 400ms...
Retrying in 400ms...
Retrying in 400ms...
```

After:
```
expected ErrForkStartWithKnownHeader encountered for 10 headers
Skipping retry

```

### Result
Reporters exit early when submitting already-known headers.

Expected errors are not treated as failures.

Reduces unnecessary load on RPC endpoints and improves reporting reliability.

---------