### PR TITLE
chore: update reporter metric for checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#330](https://github.com/babylonlabs-io/vigilante/pull/330) fix: Prevent reporter retry loop on ErrForkStartWithKnownHeader
 * [#327](https://github.com/babylonlabs-io/vigilante/pull/327) chore: bootstrap only once
 * [#336](https://github.com/babylonlabs-io/vigilante/pull/336) chore: bump btcd to v28.0
+* [#340](https://github.com/babylonlabs-io/vigilante/pull/340) chore: update reporter metric for checkpoints
 
 ## v0.23.4
 

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -87,7 +87,7 @@ func (r *Reporter) submitHeaderMsgs(msg *btclctypes.MsgInsertHeaders) error {
 				context.Background(),
 				msg,
 				[]*coserrors.Error{btclctypes.ErrForkStartWithKnownHeader}, // expected
-				nil, // abort errors
+				nil,                                                        // abort errors
 			)
 			if err != nil {
 				return fmt.Errorf("could not submit headers: %w", err)
@@ -322,15 +322,17 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 
 			continue
 		} else if res == nil {
-			r.logger.Infof("Checkpoint already submitted, for epoch: %d, tx1: %s, tx2: %s, height: %s",
+			r.logger.Infof("Checkpoint (MsgInsertBTCSpvProof) already submitted, for epoch: %d, tx1: %s, tx2: %s, height: %s",
 				ckpt.Epoch,
 				tx1Block.Txs[ckpt.Segments[0].TxIdx].Hash().String(),
 				tx2Block.Txs[ckpt.Segments[1].TxIdx].Hash().String(),
 				strconv.Itoa(int(tx1Block.Height)))
-
-			continue
+		} else {
+			r.logger.Infof("Successfully submitted checkpoint (MsgInsertBTCSpvProof) with response %d, for epoch %d, height %d",
+				res.Code, ckpt.Epoch, tx1Block.Height)
 		}
-		r.logger.Infof("Successfully submitted MsgInsertBTCSpvProof with response %d", res.Code)
+
+		// either way if we or some other reporter submitted the checkpoint, we want to update the metrics
 		r.metrics.SuccessfulCheckpointsCounter.Inc()
 		r.metrics.SecondsSinceLastCheckpointGauge.Set(0)
 		r.metrics.NewReportedCheckpointGaugeVec.WithLabelValues(

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -301,6 +301,7 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 			[]*coserrors.Error{},
 		)
 
+		// nolint:gocritic // preferred over using a switch statement
 		if err != nil {
 			r.logger.Errorf("Failed to submit MsgInsertBTCSpvProof with error %v", err)
 			r.metrics.FailedCheckpointsCounter.Inc()


### PR DESCRIPTION
We want to update the metrics even if some other reporter submitted checkpoints. Otherwise, we are getting false alarms (we don't like a lot of noise, we want a high signal-to-noise ratio).