### PR TITLE
chore: manage overlap block range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 * [#357](https://github.com/babylonlabs-io/vigilante/pull/357) imp: handle modules genesis changes
+* [#362](https://github.com/babylonlabs-io/vigilante/pull/362) chore: manage overlap block range
 
 ### Bug Fixes
 * [#359](https://github.com/babylonlabs-io/vigilante/pull/359) fix: correctly increment page for stk hash query

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -970,13 +970,9 @@ func (sew *StakingEventWatcher) fetchStakingTxsByEvent(ctx context.Context, star
 	if sew.cfg.NewDelegationsBatchSize <= uint64(math.MaxInt) {
 		batchSize = int(sew.cfg.NewDelegationsBatchSize)
 	}
-
+	startHeight = max(startHeight-1, 0)
 	for {
-		operator := ">="
-		if page > 1 {
-			operator = ">"
-		}
-		criteria := fmt.Sprintf(`tx.height%s%d AND tx.height<=%d AND %s.new_state EXISTS`, operator, startHeight, endHeight, event)
+		criteria := fmt.Sprintf(`tx.height>%d AND tx.height<=%d AND %s.new_state EXISTS`, startHeight, endHeight, event)
 		stkTxs, err := sew.babylonNodeAdapter.StakingTxHashesByEvent(ctx, event, criteria, &page, &batchSize)
 
 		if err != nil {

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -364,7 +364,7 @@ func TestActivatingAndUnbondingDelegation(t *testing.T) {
 
 func TestUnbondingLoaded(t *testing.T) {
 	t.Parallel()
-	numMatureOutputs := uint32(800)
+	numMatureOutputs := uint32(400)
 	tm := StartManager(t, numMatureOutputs, defaultEpochInterval)
 	defer tm.Stop(t)
 	tm.CatchUpBTCLightClient(t)
@@ -407,7 +407,7 @@ func TestUnbondingLoaded(t *testing.T) {
 	bsParams, err := tm.BabylonClient.BTCStakingParams()
 	require.NoError(t, err)
 
-	numStakers := 500
+	numStakers := 150
 	stakers := make([]*Staker, 0, numStakers)
 	// loop for creating staking txs
 	for i := 0; i < numStakers; i++ {

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -364,7 +364,7 @@ func TestActivatingAndUnbondingDelegation(t *testing.T) {
 
 func TestUnbondingLoaded(t *testing.T) {
 	t.Parallel()
-	numMatureOutputs := uint32(400)
+	numMatureOutputs := uint32(800)
 	tm := StartManager(t, numMatureOutputs, defaultEpochInterval)
 	defer tm.Stop(t)
 	tm.CatchUpBTCLightClient(t)
@@ -407,7 +407,7 @@ func TestUnbondingLoaded(t *testing.T) {
 	bsParams, err := tm.BabylonClient.BTCStakingParams()
 	require.NoError(t, err)
 
-	numStakers := 150
+	numStakers := 500
 	stakers := make([]*Staker, 0, numStakers)
 	// loop for creating staking txs
 	for i := 0; i < numStakers; i++ {


### PR DESCRIPTION
Avoid processing block range in the border.

Reference to: VIG: Potential duplicate event processing due to overlapping block height ranges