### PR TITLE
chore: enforce monotonic block height in unbonding watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 * [#357](https://github.com/babylonlabs-io/vigilante/pull/357) imp: handle modules genesis changes
+* [#364](https://github.com/babylonlabs-io/vigilante/pull/364) chore: enforce monotonic block height in unbonding watcher
 
 ### Bug Fixes
 * [#359](https://github.com/babylonlabs-io/vigilante/pull/359) fix: correctly increment page for stk hash query

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -888,8 +888,16 @@ func (sew *StakingEventWatcher) fetchCometBftBlockOnce() error {
 		return fmt.Errorf("error querying comet bft for new blocks: %w", err)
 	}
 
-	if latestHeight == sew.currentCometTipHeight.Load() {
-		sew.logger.Debugf("no new comet bft blocks, current height: %d", sew.currentCometTipHeight.Load())
+	currentHeight := sew.currentCometTipHeight.Load()
+
+	// Enforce monotonic block height processing
+	if latestHeight < currentHeight {
+		return fmt.Errorf("non-monotonic block height detected: latest height %d is less than current height %d",
+			latestHeight, currentHeight)
+	}
+
+	if latestHeight == currentHeight {
+		sew.logger.Debugf("no new comet bft blocks, current height: %d", currentHeight)
 
 		return nil
 	}


### PR DESCRIPTION
References: VIG: Enforce monotonic block height processing on Vigilante