### PR TITLE
chore: manage overlap block range (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#357](https://github.com/babylonlabs-io/vigilante/pull/357) imp: handle modules genesis changes
 * [#363](https://github.com/babylonlabs-io/vigilante/pull/363) chore: potential race fix
 * [#364](https://github.com/babylonlabs-io/vigilante/pull/364) chore: enforce monotonic block height in unbonding watcher
+* [#362](https://github.com/babylonlabs-io/vigilante/pull/362) chore: manage overlap block range
 
 ### Bug Fixes
 * [#359](https://github.com/babylonlabs-io/vigilante/pull/359) fix: correctly increment page for stk hash query


### PR DESCRIPTION
Avoid processing block range in the border.

Reference to: VIG: Potential duplicate event processing due to overlapping block height ranges