### PR TITLE
Use `BlockResults` query to retrieve hashes of delegation modified within the block

### DIFF
--- a/btcstaking-tracker/stakingeventwatcher/expected_babylon_client.go
+++ b/btcstaking-tracker/stakingeventwatcher/expected_babylon_client.go
@@ -2,16 +2,18 @@ package stakingeventwatcher
 
 import (
 	"context"
-	sdkerrors "cosmossdk.io/errors"
 	"fmt"
+	"strings"
+	"time"
+
+	sdkerrors "cosmossdk.io/errors"
 	"github.com/avast/retry-go/v4"
 	btclctypes "github.com/babylonlabs-io/babylon/v2/x/btclightclient/types"
 	"github.com/babylonlabs-io/vigilante/config"
 	"github.com/cosmos/cosmos-sdk/client"
-	"strings"
-	"time"
 
 	"errors"
+
 	bbnclient "github.com/babylonlabs-io/babylon/v2/client/client"
 	bbn "github.com/babylonlabs-io/babylon/v2/types"
 	btcctypes "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/types"
@@ -20,6 +22,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/cosmos/cosmos-sdk/types/query"
 )
+
+const stakingTxHashKey = "staking_tx_hash"
 
 var (
 	ErrHeaderNotKnownToBabylon       = errors.New("btc header not known to babylon")
@@ -51,7 +55,7 @@ type BabylonNodeAdapter interface {
 	QueryHeaderDepth(headerHash *chainhash.Hash) (uint32, error)
 	Params() (*BabylonParams, error)
 	CometBFTTipHeight(ctx context.Context) (int64, error)
-	StakingTxHashesByEvent(ctx context.Context, eventType string, criteria string, page, count *int) ([]string, error)
+	DelegationsModifedInBlock(ctx context.Context, height int64, eventTypes []string) ([]string, error)
 	BTCDelegation(stakingTxHash string) (*Delegation, error)
 }
 
@@ -279,6 +283,56 @@ func (bca *BabylonClientAdapter) StakingTxHashesByEvent(ctx context.Context, eve
 						stakingTxHashes = append(stakingTxHashes, stakingTxHash)
 					}
 				}
+			}
+		}
+	}
+
+	return stakingTxHashes, nil
+}
+
+func (bca *BabylonClientAdapter) DelegationsModifedInBlock(
+	ctx context.Context,
+	height int64,
+	eventTypes []string,
+) ([]string, error) {
+	var stakingTxHashes []string
+	events := make(map[string]bool)
+
+	for _, eventType := range eventTypes {
+		events[eventType] = true
+	}
+
+	res, err := bca.babylonClient.RPCClient.BlockResults(ctx, &height)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do block_results for: %d ,err: %w", height, err)
+	}
+
+	// iterate over all tx results
+	for _, txResult := range res.TxsResults {
+		for _, event := range txResult.Events {
+			// check if event type is in the list of event types we are interested in
+			if _, ok := events[event.Type]; !ok {
+				continue
+			}
+			for _, attr := range event.Attributes {
+				if attr.Key == stakingTxHashKey {
+					stakingTxHash := strings.ReplaceAll(attr.Value, `"`, "")
+					stakingTxHashes = append(stakingTxHashes, stakingTxHash)
+				}
+			}
+		}
+	}
+
+	// iterate over endblocker results
+	for _, finBlockEvent := range res.FinalizeBlockEvents {
+		if _, ok := events[finBlockEvent.Type]; !ok {
+			continue
+		}
+
+		for _, attr := range finBlockEvent.Attributes {
+			if attr.Key == stakingTxHashKey {
+				stakingTxHash := strings.ReplaceAll(attr.Value, `"`, "")
+				stakingTxHashes = append(stakingTxHashes, stakingTxHash)
 			}
 		}
 	}

--- a/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
+++ b/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
@@ -112,6 +112,21 @@ func (mr *MockBabylonNodeAdapterMockRecorder) DelegationsByStatus(status, offset
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegationsByStatus", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).DelegationsByStatus), status, offset, limit)
 }
 
+// DelegationsModifedInBlock mocks base method.
+func (m *MockBabylonNodeAdapter) DelegationsModifedInBlock(ctx context.Context, height int64, eventTypes []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelegationsModifedInBlock", ctx, height, eventTypes)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DelegationsModifedInBlock indicates an expected call of DelegationsModifedInBlock.
+func (mr *MockBabylonNodeAdapterMockRecorder) DelegationsModifedInBlock(ctx, height, eventTypes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegationsModifedInBlock", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).DelegationsModifedInBlock), ctx, height, eventTypes)
+}
+
 // IsDelegationActive mocks base method.
 func (m *MockBabylonNodeAdapter) IsDelegationActive(stakingTxHash chainhash.Hash) (bool, error) {
 	m.ctrl.T.Helper()
@@ -184,19 +199,4 @@ func (m *MockBabylonNodeAdapter) ReportUnbonding(ctx context.Context, stakingTxH
 func (mr *MockBabylonNodeAdapterMockRecorder) ReportUnbonding(ctx, stakingTxHash, stakeSpendingTx, inclusionProof, fundingTxs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportUnbonding", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).ReportUnbonding), ctx, stakingTxHash, stakeSpendingTx, inclusionProof, fundingTxs)
-}
-
-// StakingTxHashesByEvent mocks base method.
-func (m *MockBabylonNodeAdapter) StakingTxHashesByEvent(ctx context.Context, eventType, criteria string, page, count *int) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StakingTxHashesByEvent", ctx, eventType, criteria, page, count)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StakingTxHashesByEvent indicates an expected call of StakingTxHashesByEvent.
-func (mr *MockBabylonNodeAdapterMockRecorder) StakingTxHashesByEvent(ctx, eventType, criteria, page, count interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTxHashesByEvent", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).StakingTxHashesByEvent), ctx, eventType, criteria, page, count)
 }

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -902,7 +902,7 @@ func (sew *StakingEventWatcher) fetchCometBftBlockOnce() error {
 		return nil
 	}
 
-	if err := sew.fetchDelegationsByEvents(sew.currentCometTipHeight.Load(), latestHeight); err != nil {
+	if err := sew.fetchDelegationsByEvents(currentHeight, latestHeight); err != nil {
 		return fmt.Errorf("error fetching delegations by events: %w", err)
 	}
 
@@ -926,7 +926,7 @@ func (sew *StakingEventWatcher) fetchDelegationsByEvents(startHeight, endHeight 
 	events := []string{covQuorumEvent, inclusionProofReceived, btcDelegationStateUpdate}
 
 	for i := startHeight; i <= endHeight; i++ {
-		hashes, err := sew.fetchModifedDelegationsByEvents(ctx, i, events)
+		hashes, err := sew.fetchDelegationsModifiedByEvents(ctx, i, events)
 		if err != nil {
 			return fmt.Errorf("error fetching modifed delegations by events: %w", err)
 		}
@@ -956,12 +956,12 @@ func (sew *StakingEventWatcher) fetchDelegationsByEvents(startHeight, endHeight 
 	return nil
 }
 
-func (sew *StakingEventWatcher) fetchModifedDelegationsByEvents(
+func (sew *StakingEventWatcher) fetchDelegationsModifiedByEvents(
 	ctx context.Context,
 	height int64,
 	eventTypes []string,
 ) ([]string, error) {
-	sew.latency("fetchModifedDelegationsByEvents")()
+	sew.latency("fetchDelegationsModifiedByEvents")()
 	var stakingTxHashes []string
 
 	err := retry.Do(func() error {

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
@@ -2,6 +2,10 @@ package stakingeventwatcher
 
 import (
 	"context"
+	"math/rand"
+	"testing"
+	"time"
+
 	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
 	btcstakingtypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
 	"github.com/babylonlabs-io/vigilante/btcclient"
@@ -14,9 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
-	"math/rand"
-	"testing"
-	"time"
 )
 
 func TestHandlingDelegations(t *testing.T) {
@@ -166,11 +167,11 @@ func TestHandlingDelegationsByEvents(t *testing.T) {
 	}
 
 	firstCall := mockBabylonNodeAdapter.EXPECT().
-		StakingTxHashesByEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DelegationsModifedInBlock(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(stakingTxHashes, nil).Times(1)
 
 	mockBabylonNodeAdapter.EXPECT().
-		StakingTxHashesByEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DelegationsModifedInBlock(gomock.Any(), gomock.Any(), gomock.Any()).
 		After(firstCall).
 		Return(nil, nil).AnyTimes()
 


### PR DESCRIPTION
solves: https://github.com/babylonlabs-io/pm/issues/441