### PR TITLE
Use `BlockResults` query to retrieve hashes of delegation modified wi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#376](https://github.com/babylonlabs-io/vigilante/pull/376) chore: bump babylon node dep to v2 rc
 * [#381](https://github.com/babylonlabs-io/vigilante/pull/381) chore: bump babylon node dep to v2
+* [#386](https://github.com/babylonlabs-io/vigilante/pull/386) change methods of retrieving
+events
 
 ## v0.23.7
 
@@ -309,7 +311,7 @@ fix some dockerfile issue
 
 ### Bug Fixes
 
-* [#84](https://github.com/babylonlabs-io/vigilante/pull/84) fix spawning more go routines than needed when activating 
+* [#84](https://github.com/babylonlabs-io/vigilante/pull/84) fix spawning more go routines than needed when activating
 delegations, add more logging
 
 ### Improvements

--- a/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
+++ b/btcstaking-tracker/stakingeventwatcher/mock_babylon_client.go
@@ -112,6 +112,21 @@ func (mr *MockBabylonNodeAdapterMockRecorder) DelegationsByStatus(status, offset
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegationsByStatus", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).DelegationsByStatus), status, offset, limit)
 }
 
+// DelegationsModifedInBlock mocks base method.
+func (m *MockBabylonNodeAdapter) DelegationsModifedInBlock(ctx context.Context, height int64, eventTypes []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelegationsModifedInBlock", ctx, height, eventTypes)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DelegationsModifedInBlock indicates an expected call of DelegationsModifedInBlock.
+func (mr *MockBabylonNodeAdapterMockRecorder) DelegationsModifedInBlock(ctx, height, eventTypes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegationsModifedInBlock", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).DelegationsModifedInBlock), ctx, height, eventTypes)
+}
+
 // IsDelegationActive mocks base method.
 func (m *MockBabylonNodeAdapter) IsDelegationActive(stakingTxHash chainhash.Hash) (bool, error) {
 	m.ctrl.T.Helper()
@@ -184,19 +199,4 @@ func (m *MockBabylonNodeAdapter) ReportUnbonding(ctx context.Context, stakingTxH
 func (mr *MockBabylonNodeAdapterMockRecorder) ReportUnbonding(ctx, stakingTxHash, stakeSpendingTx, inclusionProof, fundingTxs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportUnbonding", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).ReportUnbonding), ctx, stakingTxHash, stakeSpendingTx, inclusionProof, fundingTxs)
-}
-
-// StakingTxHashesByEvent mocks base method.
-func (m *MockBabylonNodeAdapter) StakingTxHashesByEvent(ctx context.Context, eventType, criteria string, page, count *int) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StakingTxHashesByEvent", ctx, eventType, criteria, page, count)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// StakingTxHashesByEvent indicates an expected call of StakingTxHashesByEvent.
-func (mr *MockBabylonNodeAdapterMockRecorder) StakingTxHashesByEvent(ctx, eventType, criteria, page, count interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StakingTxHashesByEvent", reflect.TypeOf((*MockBabylonNodeAdapter)(nil).StakingTxHashesByEvent), ctx, eventType, criteria, page, count)
 }

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -5,15 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/babylonlabs-io/babylon/v2/client/babylonclient"
-	bbn "github.com/babylonlabs-io/babylon/v2/types"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/babylonlabs-io/babylon/v2/client/babylonclient"
+	bbn "github.com/babylonlabs-io/babylon/v2/types"
+	"golang.org/x/sync/semaphore"
 
 	btcctypes "github.com/babylonlabs-io/babylon/v2/x/btccheckpoint/types"
 	btcstakingtypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
@@ -903,7 +902,7 @@ func (sew *StakingEventWatcher) fetchCometBftBlockOnce() error {
 		return nil
 	}
 
-	if err := sew.fetchDelegationsByEvents(sew.currentCometTipHeight.Load(), latestHeight); err != nil {
+	if err := sew.fetchDelegationsByEvents(currentHeight, latestHeight); err != nil {
 		return fmt.Errorf("error fetching delegations by events: %w", err)
 	}
 
@@ -919,32 +918,20 @@ func (sew *StakingEventWatcher) fetchDelegationsByEvents(startHeight, endHeight 
 		btcDelegationStateUpdate = `babylon.btcstaking.v1.EventBTCDelegationStateUpdate`
 	)
 	var (
-		mu              sync.Mutex
 		stakingTxHashes []string
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
 
 	events := []string{covQuorumEvent, inclusionProofReceived, btcDelegationStateUpdate}
 
-	for _, event := range events {
-		g.Go(func() error {
-			res, err := sew.fetchStakingTxsByEvent(ctx, startHeight, endHeight, event)
-			if err != nil {
-				return fmt.Errorf("error fetching staking txs by event %s: %w", event, err)
-			}
+	for i := startHeight; i <= endHeight; i++ {
+		hashes, err := sew.fetchDelegationsModifiedByEvents(ctx, i, events)
+		if err != nil {
+			return fmt.Errorf("error fetching modified delegations by events: %w", err)
+		}
 
-			mu.Lock()
-			stakingTxHashes = append(stakingTxHashes, res...)
-			mu.Unlock()
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return err
+		stakingTxHashes = append(stakingTxHashes, hashes...)
 	}
 
 	stakingTxHashes = deduplicateStrings(stakingTxHashes)
@@ -969,55 +956,37 @@ func (sew *StakingEventWatcher) fetchDelegationsByEvents(startHeight, endHeight 
 	return nil
 }
 
-func (sew *StakingEventWatcher) fetchStakingTxsByEvent(ctx context.Context, startHeight, endHeight int64, event string) ([]string, error) {
-	sew.latency("fetchStakingTxsByEvent")()
+func (sew *StakingEventWatcher) fetchDelegationsModifiedByEvents(
+	ctx context.Context,
+	height int64,
+	eventTypes []string,
+) ([]string, error) {
+	sew.latency("fetchDelegationsModifiedByEvents")()
 	var stakingTxHashes []string
 
-	page := 1
-	batchSize := 500
-	// #nosec G115 -- performed check
-	if sew.cfg.NewDelegationsBatchSize <= uint64(math.MaxInt) {
-		batchSize = int(sew.cfg.NewDelegationsBatchSize)
-	}
+	err := retry.Do(func() error {
+		stkTxs, err := sew.babylonNodeAdapter.DelegationsModifedInBlock(ctx, height, eventTypes)
 
-	criteria := fmt.Sprintf(`tx.height>=%d AND tx.height<=%d AND %s.new_state EXISTS`, startHeight, endHeight, event)
-
-	for {
-		var stkTxs []string
-		err := retry.Do(func() error {
-			var err error
-			stkTxs, err = sew.babylonNodeAdapter.StakingTxHashesByEvent(ctx, event, criteria, &page, &batchSize)
-
-			if err != nil {
-				return fmt.Errorf("error fetching staking tx hashes by event from babylon: %w", err)
-			}
-
-			return nil
-		},
-			retry.Context(ctx),
-			retry.Attempts(5),
-			fixedDelyTypeWithJitter,
-			retry.Delay(5*time.Second),
-			retry.MaxJitter(5*time.Second),
-			retry.LastErrorOnly(true),
-		)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("error fetching staking tx hashes by event from babylon: %w", err)
 		}
 
 		stakingTxHashes = append(stakingTxHashes, stkTxs...)
 
-		if len(stkTxs) < batchSize {
-			// we received fewer results than we asked for; it means went through all of them
-			if len(stakingTxHashes) > 0 {
-				sew.logger.Debugf("fetched %d staking txs by event %s", len(stakingTxHashes), event)
-			}
-
-			return stakingTxHashes, nil
-		}
-
-		page++
+		return nil
+	},
+		retry.Context(ctx),
+		retry.Attempts(5),
+		fixedDelyTypeWithJitter,
+		retry.Delay(5*time.Second),
+		retry.MaxJitter(5*time.Second),
+		retry.LastErrorOnly(true),
+	)
+	if err != nil {
+		return nil, err
 	}
+
+	return stakingTxHashes, nil
 }
 
 func (sew *StakingEventWatcher) addToUnbondingFunc(delegation Delegation) {

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
@@ -2,6 +2,10 @@ package stakingeventwatcher
 
 import (
 	"context"
+	"math/rand"
+	"testing"
+	"time"
+
 	"github.com/babylonlabs-io/babylon/v2/testutil/datagen"
 	btcstakingtypes "github.com/babylonlabs-io/babylon/v2/x/btcstaking/types"
 	"github.com/babylonlabs-io/vigilante/btcclient"
@@ -14,9 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
-	"math/rand"
-	"testing"
-	"time"
 )
 
 func TestHandlingDelegations(t *testing.T) {
@@ -166,11 +167,11 @@ func TestHandlingDelegationsByEvents(t *testing.T) {
 	}
 
 	firstCall := mockBabylonNodeAdapter.EXPECT().
-		StakingTxHashesByEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DelegationsModifedInBlock(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(stakingTxHashes, nil).Times(1)
 
 	mockBabylonNodeAdapter.EXPECT().
-		StakingTxHashesByEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DelegationsModifedInBlock(gomock.Any(), gomock.Any(), gomock.Any()).
 		After(firstCall).
 		Return(nil, nil).AnyTimes()
 


### PR DESCRIPTION
…thin the block (#386)

solves: https://github.com/babylonlabs-io/pm/issues/441