### PR TITLE
fix: remove mutex on pk in slasher (#395) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#395](https://github.com/babylonlabs-io/vigilante/pull/395) fix: remove mutex on pk in slasher
+
 ## v0.23.8
 
 ### Improvements


### PR DESCRIPTION
Seems that we no longer get race condition on the PK. This was making slashing of delegations of a FP sequential