### PR TITLE
Fix panic when attempting to bump fee on transaction without change o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 * [#406](https://github.com/babylonlabs-io/vigilante/pull/406) fix: getting tx raw for stk expansion
+* [#410](https://github.com/babylonlabs-io/vigilante/pull/410) fix: handle missing change output in transaction resend to prevent index out of range panic
 
 ### Improvements
 

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -43,6 +43,7 @@ var (
 	ErrFeeIncrementTooSmall = errors.New("fee increment too small")
 	ErrTxNotInMempool       = errors.New("transaction not found in mempool")
 	ErrRelayFeerate         = errors.New("failed to get relay feerate")
+	ErrNoChangeOutput       = errors.New("transaction has no change output")
 )
 
 type GetLatestCheckpointFunc func() (*store.StoredCheckpoint, bool, error)
@@ -226,6 +227,11 @@ func (rl *Relayer) MaybeResubmitSecondCheckpointTx(ckpt *ckpttypes.RawCheckpoint
 					rl.logger.Warnf("Transaction %s has too many descendants, won't attempt RBF again: %v", rl.lastSubmittedCheckpoint.Tx2.TxID, err)
 
 					return nil // Don't retry with RBF if there are too many descendants
+				}
+				if errors.Is(err, ErrNoChangeOutput) {
+					rl.logger.Warnf("Transaction %s has no change output, cannot bump fee: %v", rl.lastSubmittedCheckpoint.Tx2.TxID, err)
+
+					return nil // Don't retry if there's no change output
 				}
 
 				return err
@@ -442,6 +448,13 @@ func (rl *Relayer) adjustFeeForInsufficientFeerate(
 
 // maybeResendSecondTxOfCheckpointToBTC resends the second tx of the checkpoint with bumpedFee
 func (rl *Relayer) maybeResendSecondTxOfCheckpointToBTC(tx2 *types.BtcTxInfo, bumpedFee btcutil.Amount) (*types.BtcTxInfo, error) {
+	// Check if the transaction has a change output
+	if len(tx2.Tx.TxOut) <= changePosition {
+		rl.logger.Warnf("Transaction %v has no change output (only %d outputs), cannot bump fee using RBF", tx2.TxID, len(tx2.Tx.TxOut))
+		
+		return nil, fmt.Errorf("%w: expected at least %d outputs, got %d", ErrNoChangeOutput, changePosition+1, len(tx2.Tx.TxOut))
+	}
+
 	_, status, err := rl.TxDetails(tx2.TxID, tx2.Tx.TxOut[changePosition].PkScript)
 	if err != nil {
 		return nil, err

--- a/submitter/relayer/relayer_test.go
+++ b/submitter/relayer/relayer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/golang/mock/gomock"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -1472,6 +1473,36 @@ func TestRelayer_MaybeResendSecondTxOfCheckpointToBTC(t *testing.T) {
 			},
 			expectedErrSubstr: "transaction rejected",
 		},
+		{
+			name: "transaction has no change output",
+			tx2Setup: func() *types.BtcTxInfo {
+				// Create a transaction with only one output (no change)
+				tx := wire.NewMsgTx(wire.TxVersion)
+				
+				// Add a dummy input
+				hash, _ := chainhash.NewHashFromStr("0000000000000000000000000000000000000000000000000000000000000001")
+				tx.AddTxIn(wire.NewTxIn(wire.NewOutPoint(hash, 0), nil, nil))
+				
+				// Add only OP_RETURN output (no change output)
+				builder := txscript.NewScriptBuilder()
+				dataScript, _ := builder.AddOp(txscript.OP_RETURN).AddData([]byte("test data")).Script()
+				tx.AddTxOut(wire.NewTxOut(0, dataScript))
+				
+				txID := tx.TxHash()
+				
+				return &types.BtcTxInfo{
+					TxID: &txID,
+					Tx:   tx,
+					Size: 200,
+					Fee:  btcutil.Amount(1000),
+				}
+			},
+			bumpedFee: btcutil.Amount(2000),
+			mockSetup: func(_ *mocks.MockBTCWallet, _ *types.BtcTxInfo, _ btcutil.Amount) {
+				// No mock setup needed - error should occur before any wallet calls
+			},
+			expectedErrSubstr: "transaction has no change output",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1501,6 +1532,7 @@ func TestRelayer_MaybeResendSecondTxOfCheckpointToBTC(t *testing.T) {
 		})
 	}
 }
+
 
 func TestRelayer_BuildChainedDataTx(t *testing.T) {
 	t.Parallel()
@@ -1723,3 +1755,29 @@ func TestRelayer_BuildChainedDataTx(t *testing.T) {
 		})
 	}
 }
+
+
+// MockCounter is a simple mock implementation of prometheus.Counter for testing
+type MockCounter struct {
+	value float64
+}
+
+func (m *MockCounter) Inc() {
+	m.value++
+}
+
+func (m *MockCounter) Add(delta float64) {
+	m.value += delta
+}
+
+func (m *MockCounter) Desc() <-chan *prometheus.Desc {
+	return nil
+}
+
+func (m *MockCounter) Write(*prometheus.Metric) error {
+	return nil
+}
+
+func (m *MockCounter) Describe(chan<- *prometheus.Desc) {}
+
+func (m *MockCounter) Collect(chan<- prometheus.Metric) {}


### PR DESCRIPTION
…utput (#410)

## Bug Description

The submitter daemon crashes with a panic when attempting to resubmit a checkpoint transaction that has no change output. This occurs when the code tries to access index 1
  (change position) of a transaction that only has one output.

**Error Log**
```bash
  Jul 30 09:37:40 ns3248654 submitter[1041700]: panic: runtime error: index out of range [1] with length 1
  Jul 30 09:37:40 ns3248654 submitter[1041700]: goroutine 53 [running]:
  Jul 30 09:37:40 ns3248654 submitter[1041700]: github.com/babylonlabs-io/vigilante/submitter/relayer.(*Relayer).maybeResendSecondTxOfCheckpointToBTC(0x0?, 0x0?, 0x0?)
  Jul 30 09:37:40 ns3248654 submitter[1041700]:         /home/ubuntu/vigilante/submitter/relayer/relayer.go:444 +0x633
```


## Root Cause

  The code assumes all checkpoint transactions have at least 2 outputs:
  - Index 0: Checkpoint data (OP_RETURN)
  - Index 1: Change output

However, when a transaction uses the entire UTXO for fees, there is no change output, causing an index out of range panic at relayer.go:445.

  Affected Version

  - Current main branch
- Transaction example: https://mempool.space/ko/signet/tx/1c6950268613ed7d67eec1b154b020218585ae22ebdcb6b2b2e253d5665cb5d0

## Proposed Solution

Add validation to check if a transaction has a change output before attempting to access it:

```go
  // Check if the transaction has a change output
  if len(tx2.Tx.TxOut) <= changePosition {
      rl.logger.Warnf("Transaction %v has no change output (only %d outputs), cannot bump fee using RBF", tx2.TxID, len(tx2.Tx.TxOut))
      return nil, fmt.Errorf("%w: expected at least %d outputs, got %d", ErrNoChangeOutput, changePosition+1, len(tx2.Tx.TxOut))
  }
```

##  Impact

  - Severity: High - Causes service crash
  - Frequency: Occurs when transactions have no change output
- Affected Component: Submitter daemon's transaction resubmission logic



## Testing

Added unit test to verify the fix handles transactions without change output gracefully:
- Test case: TestRelayer_MaybeResendSecondTxOfCheckpointToBTC/transaction_has_no_change_output
  - Verifies no panic occurs and proper error is returned