### PR TITLE
fix: nil check in calculateBumpedFee (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#423](https://github.com/babylonlabs-io/vigilante/pull/423) Fix nil pointer panic in calculateBumpedFee when lastSubmittedCheckpoint.Tx2 is nil
+
 ## v0.24.0-rc.2
 
 ### Improvements

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -315,6 +315,11 @@ func (rl *Relayer) isNotRBFError(previousFailure error) bool {
 // calculateBumpedFee calculates the bumped fees of the second tx of the checkpoint
 // based on the current BTC load, considering both tx sizes and RBF requirements
 func (rl *Relayer) calculateBumpedFee(ckptInfo *types.CheckpointInfo, previousFailure error) (btcutil.Amount, error) {
+	// Check if ckptInfo or Tx2 is nil to prevent panic
+	if ckptInfo == nil || ckptInfo.Tx2 == nil {
+		return 0, fmt.Errorf("checkpoint info or Tx2 is nil")
+	}
+
 	currentFeeRate := rl.getFeeRate()
 
 	// Convert to Satoshis per byte (SatPerKVByte is per 1000 bytes)


### PR DESCRIPTION
## Summary

This PR fixes a critical nil pointer panic that occurs in the submitter when attempting to resubmit checkpoints.

## Problem

The submitter crashes with a nil pointer dereference when trying to access `ckptInfo.Tx2.Size` in calculateBumpedFee(). This happens because:
1. lastSubmittedCheckpoint is initialized as an empty `&types.CheckpointInfo{}` with nil Tx1 and Tx2 fields
2. When the first checkpoint resubmission is attempted, the code tries to access `Tx2.Size` without checking if Tx2 is nil

## Solution

Added nil checks at the beginning of calculateBumpedFee() to validate that both ckptInfo and ckptInfo.Tx2 are not nil before accessing their fields.

## Error Log
```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x39bebec]
  goroutine 90 [running]:
  github.com/babylonlabs-io/vigilante/submitter/relayer.(*Relayer).calculateBumpedFee(0xc001428640, 0xc00141d4a0, {0x0, 0x0})
          /home/ubuntu/vigilante/submitter/relayer/relayer.go:324 +0x6c
```

## Testing

- The fix prevents the panic by returning an error when nil values are encountered
  - This allows the submitter to continue operating without crashing

## Type of Change

  - Bug fix (non-breaking change which fixes an issue)