### PR TITLE
fix: try fix activating stk exp (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#423](https://github.com/babylonlabs-io/vigilante/pull/423) Fix nil pointer panic in calculateBumpedFee when lastSubmittedCheckpoint.Tx2 is nil
 * [#427](https://github.com/babylonlabs-io/vigilante/pull/427) fix: slashing multistaked
+* [#428](https://github.com/babylonlabs-io/vigilante/pull/428) fix: try fix activating stk exp
 
 ## v0.24.0-rc.2
 


### PR DESCRIPTION
- waitGroup in checkSpend was making it execute in sync, meaning that we would be executing the blockNotifier loop until it finishes. It also has inf retries routines (when we wait for tx or inclusion proofs). We are safe to proceed without WG as we have checks in place to avoid double processing