### PR TITLE
ci: add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: check-case-conflict          # Case-insensitive filesystem issues
       - id: check-executables-have-shebangs  # Ensure executables have a valid shebang
 
-# For allowing secrets to be committed, add this comment: # gitleaks:allow
+  # For allowing secrets to be committed, add this comment: # gitleaks:allow
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:


### PR DESCRIPTION
## Summary
- Add pre-commit hooks configuration for code quality checks

### Hooks included:
- Prevent committing to main directly
- Check for merge conflicts
- Validate YAML, JSON, and TOML files
- Detect private keys
- Fix trailing whitespace and end-of-file issues
- Normalize line endings to LF
- Check for case conflicts
- Ensure executables have shebangs
- Detect hardcoded secrets with gitleaks

## Requirements
- MacOS: `brew install pre-commit`
- Linux: `pip3 install pre-commit`