### PR TITLE
feat(reporter): async header submission for ETH backend

### DIFF
--- a/config/ethereum.go
+++ b/config/ethereum.go
@@ -34,6 +34,12 @@ type EthereumConfig struct {
 
 	// Maximum number of blocks to wait for safe/finalized confirmation
 	MaxConfirmationBlocks uint64 `mapstructure:"max-confirmation-blocks"`
+
+	// HeaderBatchSize is the max number of BTC blocks to batch before submitting to contract (default: 10)
+	HeaderBatchSize uint32 `mapstructure:"header-batch-size"`
+
+	// HeaderBatchTimeout is how long to wait before submitting a partial batch (default: 10s)
+	HeaderBatchTimeout time.Duration `mapstructure:"header-batch-timeout"`
 }
 
 // Validate checks the Ethereum configuration
@@ -72,6 +78,14 @@ func (cfg *EthereumConfig) Validate() error {
 		cfg.MaxConfirmationBlocks = 100 // default
 	}
 
+	if cfg.HeaderBatchSize == 0 {
+		cfg.HeaderBatchSize = 10 // default
+	}
+
+	if cfg.HeaderBatchTimeout == 0 {
+		cfg.HeaderBatchTimeout = 10 * time.Second // default
+	}
+
 	return nil
 }
 
@@ -87,5 +101,7 @@ func DefaultEthereumConfig() EthereumConfig {
 		ConfirmationMode:      "safe",
 		ConfirmationTimeout:   15 * time.Minute,
 		MaxConfirmationBlocks: 100,
+		HeaderBatchSize:       10,
+		HeaderBatchTimeout:    10 * time.Second,
 	}
 }

--- a/reporter/ethereum_backend.go
+++ b/reporter/ethereum_backend.go
@@ -405,6 +405,11 @@ func (e *EthereumBackend) Stop() error {
 	return nil
 }
 
+// GetConfig returns the Ethereum configuration
+func (e *EthereumBackend) GetConfig() *config.EthereumConfig {
+	return e.cfg
+}
+
 // reverseBytes reverses a byte slice in place (for endianness conversion)
 func reverseBytes(b []byte) {
 	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {


### PR DESCRIPTION
  - Decouple block notification from ETH header submission to prevent blocking on slow confirmations
  - Add configurable batching for ETH header submissions