### PR TITLE
ci: enhance backport workflow security

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,6 +21,9 @@ jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
@@ -33,6 +36,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pinned action to commit SHA — https://github.com/tibdex/backport/commit/9565281eda0731b1d20c4025c43339fb0a23812e # v2. A compromised or force-pushed v2 tag can no longer substitute malicious code; the runner will only execute the exact commit that was audited.

Restricted permissions — added an explicit block with only contents: write (to push the backport branch) and pull-requests: write (to open the PR and post comments). All other permissions (actions, id-token, packages, etc.) default to none, limiting blast radius if the action is ever abused.