### PR TITLE
refactor: separate context creation from quit monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#540](https://github.com/babylonlabs-io/vigilante/pull/540) fix: resolve gosec G118 by moving context.WithCancel to call sites, replacing quitContext with quitMonitor helper
 * [#508](https://github.com/babylonlabs-io/vigilante/pull/508) chore: update sample-vigilante.yml
 * [#506](https://github.com/babylonlabs-io/vigilante/pull/506) chore(deps): bump the go_modules group
 

--- a/btcstaking-tracker/atomicslasher/atomic_slasher.go
+++ b/btcstaking-tracker/atomicslasher/atomic_slasher.go
@@ -105,19 +105,15 @@ func (as *AtomicSlasher) Stop() error {
 	return stopErr
 }
 
-func (as *AtomicSlasher) quitContext() (context.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (as *AtomicSlasher) quitMonitor(ctx context.Context, cancel context.CancelFunc) {
 	as.wg.Add(1)
 	go func() {
-		defer cancel()
 		defer as.wg.Done()
 
 		select {
 		case <-as.quit:
-
+			cancel()
 		case <-ctx.Done():
 		}
 	}()
-
-	return ctx, cancel
 }

--- a/btcstaking-tracker/atomicslasher/routines.go
+++ b/btcstaking-tracker/atomicslasher/routines.go
@@ -1,6 +1,7 @@
 package atomicslasher
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -118,7 +119,8 @@ func (as *AtomicSlasher) selectiveSlashingReporter() {
 			// get delegation
 			stakingTxHash := slashingTxInfo.StakingTxHash
 			stakingTxHashStr := stakingTxHash.String()
-			ctx, cancel := as.quitContext()
+			ctx, cancel := context.WithCancel(context.Background())
+			as.quitMonitor(ctx, cancel)
 			btcDelResp, err := as.bbnAdapter.BTCDelegation(ctx, stakingTxHashStr)
 			cancel()
 			if err != nil {
@@ -131,7 +133,8 @@ func (as *AtomicSlasher) selectiveSlashingReporter() {
 				continue
 			}
 			// get parameter at the version of this BTC delegation
-			ctx, cancel = as.quitContext()
+			ctx, cancel = context.WithCancel(context.Background())
+			as.quitMonitor(ctx, cancel)
 			paramsVersion := btcDelResp.BtcDelegation.ParamsVersion
 			bsParams, err := as.bbnAdapter.BTCStakingParams(ctx, paramsVersion)
 			cancel()
@@ -162,7 +165,8 @@ func (as *AtomicSlasher) selectiveSlashingReporter() {
 			}
 
 			// skip if the finality provider is already slashed
-			ctx, cancel = as.quitContext()
+			ctx, cancel = context.WithCancel(context.Background())
+			as.quitMonitor(ctx, cancel)
 			isSlashed, err := as.bbnAdapter.IsFPSlashed(ctx, fpPK)
 			if err != nil {
 				as.logger.Error(
@@ -208,7 +212,8 @@ func (as *AtomicSlasher) selectiveSlashingReporter() {
 			}
 
 			// report selective slashing to Babylon
-			ctx, cancel = as.quitContext()
+			ctx, cancel = context.WithCancel(context.Background())
+			as.quitMonitor(ctx, cancel)
 			if err := as.bbnAdapter.ReportSelectiveSlashing(ctx, fpSK); err != nil {
 				// TODO: this implies that all signed covenant members collude with
 				// the finality provider. Decide what to do in this case

--- a/btcstaking-tracker/btcslasher/slasher.go
+++ b/btcstaking-tracker/btcslasher/slasher.go
@@ -91,21 +91,17 @@ func New(
 	}, nil
 }
 
-func (bs *BTCSlasher) quitContext() (context.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (bs *BTCSlasher) quitMonitor(ctx context.Context, cancel context.CancelFunc) {
 	bs.wg.Add(1)
 	go func() {
-		defer cancel()
 		defer bs.wg.Done()
 
 		select {
 		case <-bs.quit:
-
+			cancel()
 		case <-ctx.Done():
 		}
 	}()
-
-	return ctx, cancel
 }
 
 func (bs *BTCSlasher) LoadParams() error {
@@ -223,8 +219,9 @@ func (bs *BTCSlasher) SlashFinalityProvider(extractedFpBTCSK *btcec.PrivateKey) 
 		bs.wg.Add(1)
 		go func(d *bstypes.BTCDelegationResponse) {
 			defer bs.wg.Done()
-			ctx, cancel := bs.quitContext()
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+			bs.quitMonitor(ctx, cancel)
 
 			// Acquire the semaphore before interacting with the BTC node
 			if err := sem.Acquire(ctx, 1); err != nil {

--- a/btcstaking-tracker/btcslasher/slasher_utils.go
+++ b/btcstaking-tracker/btcslasher/slasher_utils.go
@@ -57,8 +57,9 @@ func (bs *BTCSlasher) slashBTCDelegation(
 	del *bstypes.BTCDelegationResponse,
 ) {
 	var txHash *chainhash.Hash
-	ctx, cancel := bs.quitContext()
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	bs.quitMonitor(ctx, cancel)
 
 	err := retry.Do(func() error {
 		innerCtx, innerCancel := context.WithCancel(ctx)

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -42,21 +42,17 @@ var (
 	ErrSpendPathNotUnbonding = errors.New("spending tx is not unbonding path")
 )
 
-func (sew *StakingEventWatcher) quitContext() (context.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (sew *StakingEventWatcher) quitMonitor(ctx context.Context, cancel context.CancelFunc) {
 	sew.wg.Add(1)
 	go func() {
-		defer cancel()
 		defer sew.wg.Done()
 
 		select {
 		case <-sew.quit:
-
+			cancel()
 		case <-ctx.Done():
 		}
 	}()
-
-	return ctx, cancel
 }
 
 type newDelegation struct {
@@ -588,8 +584,9 @@ func (sew *StakingEventWatcher) checkSpend() error {
 					sew.logger.Warnf("error updating activation Status for staking tx %s: %v", del.StakingTx.TxHash(), err)
 				}
 			}()
-			innerCtx, innerCancel := sew.quitContext()
+			innerCtx, innerCancel := context.WithCancel(context.Background())
 			defer innerCancel()
+			sew.quitMonitor(innerCtx, innerCancel)
 
 			txHash, err := chainhash.NewHashFromStr(response.TxID)
 			if err != nil {
@@ -794,8 +791,9 @@ func (sew *StakingEventWatcher) activateBtcDelegation(
 	sew.metrics.NumberOfActivationInProgress.Inc()
 	defer sew.metrics.NumberOfActivationInProgress.Dec()
 
-	ctx, cancel := sew.quitContext()
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	sew.quitMonitor(ctx, cancel)
 
 	defer sew.latency("activateBtcDelegation")()
 	defer func() {

--- a/reporter/bootstrapping.go
+++ b/reporter/bootstrapping.go
@@ -155,28 +155,25 @@ func (r *Reporter) bootstrap() error {
 	return nil
 }
 
-func (r *Reporter) reporterQuitCtx() (context.Context, func()) {
+func (r *Reporter) reporterQuitMonitor(ctx context.Context, cancel context.CancelFunc) {
 	quit := r.quitChan()
-	ctx, cancel := context.WithCancel(context.Background())
 	r.wg.Add(1)
 	go func() {
-		defer cancel()
 		defer r.wg.Done()
 
 		select {
 		case <-quit:
-
+			cancel()
 		case <-ctx.Done():
 		}
 	}()
-
-	return ctx, cancel
 }
 
 func (r *Reporter) bootstrapWithRetries() {
 	// if we are exiting, we need to cancel this process
-	ctx, cancel := r.reporterQuitCtx()
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	r.reporterQuitMonitor(ctx, cancel)
 	if err := retry.Do(func() error {
 		// we don't want to allow concurrent bootstrap process, if bootstrap is already in progress
 		// we should wait for it to finish


### PR DESCRIPTION
got gosec error, claude auto apply fix
```

[/github/workspace/reporter/bootstrapping.go:160] - G118 (CWE-400): context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (Confidence: HIGH, Severity: MEDIUM)
    159: 	quit := r.quitChan()
  > 160: 	ctx, cancel := context.WithCancel(context.Background())
    161: 	r.wg.Add(1)

Autofix: 

[/github/workspace/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go:46] - G118 (CWE-400): context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (Confidence: HIGH, Severity: MEDIUM)
    45: func (sew *StakingEventWatcher) quitContext() (context.Context, func()) {
  > 46: 	ctx, cancel := context.WithCancel(context.Background())
    47: 	sew.wg.Add(1)

Autofix: 

[/github/workspace/btcstaking-tracker/btcslasher/slasher.go:95] - G118 (CWE-400): context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (Confidence: HIGH, Severity: MEDIUM)
    94: func (bs *BTCSlasher) quitContext() (context.Context, func()) {
  > 95: 	ctx, cancel := context.WithCancel(context.Background())
    96: 	bs.wg.Add(1)

Autofix: 

[/github/workspace/btcstaking-tracker/atomicslasher/atomic_slasher.go:109] - G118 (CWE-400): context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (Confidence: HIGH, Severity: MEDIUM)
    108: func (as *AtomicSlasher) quitContext() (context.Context, func()) {
  > 109: 	ctx, cancel := context.WithCancel(context.Background())
    110: 	as.wg.Add(1)

Autofix: 
```
https://github.com/babylonlabs-io/vigilante/actions/runs/23669269080/job/68958802177?pr=539

