### PR TITLE
fix(btcslasher): durable bootstrap cursor via pending evidence store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
-* [#537](https://github.com/babylonlabs-io/vigilante/pull/537) fix(btcslasher): durable bootstrap cursor via pending evidence store
+* [#543](https://github.com/babylonlabs-io/vigilante/pull/543) fix(btcslasher): durable bootstrap cursor via pending evidence store
 * [#541](https://github.com/babylonlabs-io/vigilante/pull/541) fix: rehydrate submitter `lastSubmittedCheckpoint` from store on restart so the RBF path has valid Tx1/Tx2 info instead of panicking / looping on a nil Tx2
 * [#513](https://github.com/babylonlabs-io/vigilante/pull/513) fix: replace panic with error return for non-unbonding spending paths
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+* [#537](https://github.com/babylonlabs-io/vigilante/pull/537) fix(btcslasher): durable bootstrap cursor via pending evidence store
 * [#541](https://github.com/babylonlabs-io/vigilante/pull/541) fix: rehydrate submitter `lastSubmittedCheckpoint` from store on restart so the RBF path has valid Tx1/Tx2 info instead of panicking / looping on a nil Tx2
 * [#513](https://github.com/babylonlabs-io/vigilante/pull/513) fix: replace panic with error return for non-unbonding spending paths
 

--- a/btcstaking-tracker/btcslasher/bootstrapping.go
+++ b/btcstaking-tracker/btcslasher/bootstrapping.go
@@ -28,6 +28,14 @@ func (bs *BTCSlasher) Bootstrap(startHeight uint64) error {
 		return err
 	}
 
+	// Replay any pending evidences from a previous run before processing new
+	// evidences. This is what makes bootstrap progress durable across restarts:
+	// a Babylon ListEvidences(startHeight) call cannot rediscover an FP whose
+	// first slashable evidence is below startHeight, so we keep our own queue.
+	if err := bs.replayPendingEvidences(); err != nil {
+		return fmt.Errorf("failed to replay pending evidences: %w", err)
+	}
+
 	lastSlashedHeight, err := bs.processEvidencesFromHeight(startHeight)
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap BTC slasher: %w", err)
@@ -45,6 +53,56 @@ func (bs *BTCSlasher) Bootstrap(startHeight uint64) error {
 	}
 
 	return nil
+}
+
+// replayPendingEvidences reads all evidences from the pending bucket and
+// re-dispatches slashing for each. Bitcoin tx submission is idempotent via
+// isTxSubmittedToBitcoin, so replay is safe even if a tx was already
+// broadcast in a previous run.
+func (bs *BTCSlasher) replayPendingEvidences() error {
+	pending, err := bs.store.ListPendingEvidences()
+	if err != nil {
+		return fmt.Errorf("failed to list pending evidences: %w", err)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	bs.logger.Infof("replaying %d pending evidences from previous run", len(pending))
+
+	var accumulatedErrs error
+	for _, ev := range pending {
+		btcPK, err := types.NewBIP340PubKeyFromHex(ev.FpBtcPkHex)
+		if err != nil {
+			bs.logger.Errorf("pending evidence has malformed fp_btc_pk_hex %q: %v", ev.FpBtcPkHex, err)
+			accumulatedErrs = multierror.Append(accumulatedErrs, err)
+
+			continue
+		}
+		e := ftypes.Evidence{
+			FpBtcPk:              btcPK,
+			BlockHeight:          ev.BlockHeight,
+			PubRand:              ev.PubRand,
+			CanonicalAppHash:     ev.CanonicalAppHash,
+			ForkAppHash:          ev.ForkAppHash,
+			CanonicalFinalitySig: ev.CanonicalFinalitySig,
+			ForkFinalitySig:      ev.ForkFinalitySig,
+		}
+		fpBTCSK, err := e.ExtractBTCSK()
+		if err != nil {
+			bs.logger.Errorf("pending evidence at height %d for fp %s is no longer slashable: %v", ev.BlockHeight, ev.FpBtcPkHex, err)
+			accumulatedErrs = multierror.Append(accumulatedErrs, err)
+
+			continue
+		}
+		if err := bs.SlashFinalityProvider(fpBTCSK); err != nil {
+			bs.logger.Errorf("failed to redispatch slashing for fp %s at height %d: %v", ev.FpBtcPkHex, ev.BlockHeight, err)
+			accumulatedErrs = multierror.Append(accumulatedErrs, err)
+
+			continue
+		}
+	}
+
+	return accumulatedErrs
 }
 
 func (bs *BTCSlasher) LastEvidencesHeight() (uint64, bool, error) {
@@ -81,6 +139,15 @@ func (bs *BTCSlasher) processEvidencesFromHeight(startHeight uint64) (uint64, er
 			fpBTCSK, err := e.ExtractBTCSK()
 			if err != nil {
 				bs.logger.Errorf("failed to extract BTC SK of the slashed finality provider %s: %v", fpBTCPKHex, err)
+				accumulatedErrs = multierror.Append(accumulatedErrs, err)
+
+				continue
+			}
+
+			// Persist the evidence to the pending bucket BEFORE dispatching slashing.
+			// On restart, pending entries will be replayed regardless of cursor.
+			if err := bs.store.PutPendingEvidence(evidence); err != nil {
+				bs.logger.Errorf("failed to persist pending evidence for fp %s at height %d: %v", fpBTCPKHex, evidence.BlockHeight, err)
 				accumulatedErrs = multierror.Append(accumulatedErrs, err)
 
 				continue

--- a/btcstaking-tracker/btcslasher/bootstrapping_test.go
+++ b/btcstaking-tracker/btcslasher/bootstrapping_test.go
@@ -19,6 +19,7 @@ import (
 	bstypes "github.com/babylonlabs-io/babylon/v4/x/btcstaking/types"
 	ftypes "github.com/babylonlabs-io/babylon/v4/x/finality/types"
 	"github.com/babylonlabs-io/vigilante/btcstaking-tracker/btcslasher"
+	storepkg "github.com/babylonlabs-io/vigilante/btcstaking-tracker/btcslasher/store"
 	"github.com/babylonlabs-io/vigilante/config"
 	"github.com/babylonlabs-io/vigilante/metrics"
 	"github.com/babylonlabs-io/vigilante/testutil/mocks"
@@ -219,4 +220,285 @@ func FuzzSlasher_Bootstrapping(f *testing.F) {
 
 		btcSlasher.WaitForShutdown()
 	})
+}
+
+func TestBootstrap_PersistsEvidenceToPendingBeforeDispatch(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	net := &chaincfg.SimNetParams
+	commonCfg := config.DefaultCommonConfig()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonQuerier := btcslasher.NewMockBabylonQueryClient(ctrl)
+	mockBTCClient := mocks.NewMockBTCClient(ctrl)
+	btccParams := &btcctypes.QueryParamsResponse{Params: btcctypes.Params{BtcConfirmationDepth: 10, CheckpointFinalizationTimeout: 100}}
+	mockBabylonQuerier.EXPECT().BTCCheckpointParams().Return(btccParams, nil).AnyTimes()
+	// Returning an error from FinalityProviderDelegations causes
+	// SlashFinalityProvider to fail before spawning the per-FP cleanup goroutine,
+	// so the pending entry remains in the kvdb and we can verify it was persisted.
+	mockBabylonQuerier.EXPECT().FinalityProviderDelegations(gomock.Any(), gomock.Any()).Return(
+		nil, fmt.Errorf("simulated query error to keep pending entry alive for inspection"),
+	).AnyTimes()
+
+	logger, err := config.NewRootLogger("auto", "debug")
+	require.NoError(t, err)
+	slashedFPSKChan := make(chan *btcec.PrivateKey, 100)
+	db := testutil.MakeTestBackend(t)
+	bs, err := btcslasher.New(
+		logger, mockBTCClient, mockBabylonQuerier, net,
+		commonCfg.RetrySleepTime, commonCfg.MaxRetrySleepTime, commonCfg.MaxRetryTimes,
+		config.MaxSlashingConcurrency, slashedFPSKChan,
+		metrics.NewBTCStakingTrackerMetrics().SlasherMetrics, 5*time.Second, db,
+	)
+	require.NoError(t, err)
+
+	fpSK, fpPK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
+	evidence, err := datagen.GenRandomEvidence(r, fpSK, 1234)
+	require.NoError(t, err)
+	er := &ftypes.EvidenceResponse{
+		FpBtcPkHex:           fpBTCPK.MarshalHex(),
+		BlockHeight:          evidence.BlockHeight,
+		PubRand:              evidence.PubRand,
+		CanonicalAppHash:     evidence.CanonicalAppHash,
+		ForkAppHash:          evidence.ForkAppHash,
+		CanonicalFinalitySig: evidence.CanonicalFinalitySig,
+		ForkFinalitySig:      evidence.ForkFinalitySig,
+	}
+	mockBabylonQuerier.EXPECT().ListEvidences(gomock.Any(), gomock.Any()).Return(
+		&ftypes.QueryListEvidencesResponse{
+			Evidences:  []*ftypes.EvidenceResponse{er},
+			Pagination: &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+
+	// Bootstrap returns an error because the simulated SlashFinalityProvider
+	// failure is captured. The important assertion is that the pending entry
+	// was persisted before the dispatch failed, which is what makes the entry
+	// available for replay on restart.
+	require.Error(t, bs.Bootstrap(0))
+
+	inspectStore, err := storepkg.NewSlasherStore(db)
+	require.NoError(t, err)
+	pending, err := inspectStore.ListPendingEvidences()
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, er.BlockHeight, pending[0].BlockHeight)
+	require.Equal(t, er.FpBtcPkHex, pending[0].FpBtcPkHex)
+}
+
+// Regression test for Immunify VIG-04/05: an evidence persisted in the pending
+// bucket from a prior run must be re-processed even if the stored cursor has
+// advanced past it (since Babylon's ListEvidences(startHeight) would filter
+// out an FP whose first slashable evidence is below startHeight).
+func TestBootstrap_ReplaysPendingFromPreviousRun(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	net := &chaincfg.SimNetParams
+	commonCfg := config.DefaultCommonConfig()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonQuerier := btcslasher.NewMockBabylonQueryClient(ctrl)
+	mockBTCClient := mocks.NewMockBTCClient(ctrl)
+	btccParams := &btcctypes.QueryParamsResponse{Params: btcctypes.Params{BtcConfirmationDepth: 10, CheckpointFinalizationTimeout: 100}}
+	mockBabylonQuerier.EXPECT().BTCCheckpointParams().Return(btccParams, nil).AnyTimes()
+
+	logger, err := config.NewRootLogger("auto", "debug")
+	require.NoError(t, err)
+	slashedFPSKChan := make(chan *btcec.PrivateKey, 100)
+	db := testutil.MakeTestBackend(t)
+
+	// Pre-seed the kvdb with: cursor advanced to H2, pending entry at H1<H2.
+	preStore, err := storepkg.NewSlasherStore(db)
+	require.NoError(t, err)
+	require.NoError(t, preStore.PutHeight(2000))
+
+	fpSK, fpPK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
+	evidence, err := datagen.GenRandomEvidence(r, fpSK, 1000) // H1 = 1000 < H2 = 2000
+	require.NoError(t, err)
+	pendingER := &ftypes.EvidenceResponse{
+		FpBtcPkHex:           fpBTCPK.MarshalHex(),
+		BlockHeight:          evidence.BlockHeight,
+		PubRand:              evidence.PubRand,
+		CanonicalAppHash:     evidence.CanonicalAppHash,
+		ForkAppHash:          evidence.ForkAppHash,
+		CanonicalFinalitySig: evidence.CanonicalFinalitySig,
+		ForkFinalitySig:      evidence.ForkFinalitySig,
+	}
+	require.NoError(t, preStore.PutPendingEvidence(pendingER))
+
+	bs, err := btcslasher.New(
+		logger, mockBTCClient, mockBabylonQuerier, net,
+		commonCfg.RetrySleepTime, commonCfg.MaxRetrySleepTime, commonCfg.MaxRetryTimes,
+		config.MaxSlashingConcurrency, slashedFPSKChan,
+		metrics.NewBTCStakingTrackerMetrics().SlasherMetrics, 5*time.Second, db,
+	)
+	require.NoError(t, err)
+
+	// Babylon ListEvidences (called for the cursor=2000 forward sweep) returns
+	// nothing — mirroring the post-restart scenario where FP1 is filtered out.
+	mockBabylonQuerier.EXPECT().ListEvidences(gomock.Any(), gomock.Any()).Return(
+		&ftypes.QueryListEvidencesResponse{
+			Evidences:  nil,
+			Pagination: &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+
+	// FinalityProviderDelegations should be called specifically for FP1 because
+	// the pending entry replays it. Returning empty so we don't have to mock BTC.
+	mockBabylonQuerier.EXPECT().FinalityProviderDelegations(gomock.Eq(fpBTCPK.MarshalHex()), gomock.Any()).Return(
+		&bstypes.QueryFinalityProviderDelegationsResponse{
+			BtcDelegatorDelegations: nil,
+			Pagination:              &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+
+	require.NoError(t, bs.Bootstrap(2000))
+}
+
+// After Bootstrap finishes and all per-delegation goroutines reach a terminal
+// state, the pending bucket should be empty. (With zero delegations, the
+// terminal condition is trivially met as soon as SlashFinalityProvider's wg
+// has nothing to wait on.)
+func TestBootstrap_DeletesPendingAfterCompletion(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	net := &chaincfg.SimNetParams
+	commonCfg := config.DefaultCommonConfig()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonQuerier := btcslasher.NewMockBabylonQueryClient(ctrl)
+	mockBTCClient := mocks.NewMockBTCClient(ctrl)
+	btccParams := &btcctypes.QueryParamsResponse{Params: btcctypes.Params{BtcConfirmationDepth: 10, CheckpointFinalizationTimeout: 100}}
+	mockBabylonQuerier.EXPECT().BTCCheckpointParams().Return(btccParams, nil).AnyTimes()
+	// FP has zero delegations, so completion is immediate.
+	mockBabylonQuerier.EXPECT().FinalityProviderDelegations(gomock.Any(), gomock.Any()).Return(
+		&bstypes.QueryFinalityProviderDelegationsResponse{
+			BtcDelegatorDelegations: nil,
+			Pagination:              &query.PageResponse{NextKey: nil},
+		}, nil).AnyTimes()
+
+	logger, err := config.NewRootLogger("auto", "debug")
+	require.NoError(t, err)
+	db := testutil.MakeTestBackend(t)
+	bs, err := btcslasher.New(
+		logger, mockBTCClient, mockBabylonQuerier, net,
+		commonCfg.RetrySleepTime, commonCfg.MaxRetrySleepTime, commonCfg.MaxRetryTimes,
+		config.MaxSlashingConcurrency, make(chan *btcec.PrivateKey, 100),
+		metrics.NewBTCStakingTrackerMetrics().SlasherMetrics, 5*time.Second, db,
+	)
+	require.NoError(t, err)
+
+	fpSK, fpPK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
+	evidence, err := datagen.GenRandomEvidence(r, fpSK, 1234)
+	require.NoError(t, err)
+	er := &ftypes.EvidenceResponse{
+		FpBtcPkHex:           fpBTCPK.MarshalHex(),
+		BlockHeight:          evidence.BlockHeight,
+		PubRand:              evidence.PubRand,
+		CanonicalAppHash:     evidence.CanonicalAppHash,
+		ForkAppHash:          evidence.ForkAppHash,
+		CanonicalFinalitySig: evidence.CanonicalFinalitySig,
+		ForkFinalitySig:      evidence.ForkFinalitySig,
+	}
+	mockBabylonQuerier.EXPECT().ListEvidences(gomock.Any(), gomock.Any()).Return(
+		&ftypes.QueryListEvidencesResponse{
+			Evidences:  []*ftypes.EvidenceResponse{er},
+			Pagination: &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+
+	require.NoError(t, bs.Bootstrap(0))
+	bs.WaitForShutdown() // wait for any spawned goroutines to finish
+
+	inspect, err := storepkg.NewSlasherStore(db)
+	require.NoError(t, err)
+	pending, err := inspect.ListPendingEvidences()
+	require.NoError(t, err)
+	require.Empty(t, pending, "pending bucket should be empty after all delegations terminate")
+}
+
+// TestBootstrap_RestartReprocessesEarlierFP_VIG04 reproduces the Immunify VIG-04
+// scenario at unit level. Two evidences exist at heights H1 < H2. In the first
+// run we simulate a failed BTC broadcast for FP1 by canceling the slasher mid
+// Bootstrap, leaving the pending entry for FP1 in the store. Then we instantiate
+// a fresh slasher backed by the same kvdb and verify that on restart it
+// re-queries Babylon delegations specifically for FP1, even though the cursor
+// is at H2 (and ListEvidences(H2) does not return FP1).
+func TestBootstrap_RestartReprocessesEarlierFP_VIG04(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+	net := &chaincfg.SimNetParams
+	commonCfg := config.DefaultCommonConfig()
+	logger, err := config.NewRootLogger("auto", "debug")
+	require.NoError(t, err)
+
+	// Shared kvdb between first and second slasher instance — simulates restart.
+	db := testutil.MakeTestBackend(t)
+
+	// FP1 keypair + evidence at H1 = 1000
+	fp1SK, fp1PK, err := datagen.GenRandomBTCKeyPair(r)
+	require.NoError(t, err)
+	fp1BTCPK := bbn.NewBIP340PubKeyFromBTCPK(fp1PK)
+	ev1, err := datagen.GenRandomEvidence(r, fp1SK, 1000)
+	require.NoError(t, err)
+	er1 := &ftypes.EvidenceResponse{
+		FpBtcPkHex:           fp1BTCPK.MarshalHex(),
+		BlockHeight:          ev1.BlockHeight,
+		PubRand:              ev1.PubRand,
+		CanonicalAppHash:     ev1.CanonicalAppHash,
+		ForkAppHash:          ev1.ForkAppHash,
+		CanonicalFinalitySig: ev1.CanonicalFinalitySig,
+		ForkFinalitySig:      ev1.ForkFinalitySig,
+	}
+
+	// Pre-seed the kvdb to look like a previous run that observed evidence at
+	// H1 and then crashed: pending bucket has FP1@H1, cursor = 2000.
+	preStore, err := storepkg.NewSlasherStore(db)
+	require.NoError(t, err)
+	require.NoError(t, preStore.PutPendingEvidence(er1))
+	require.NoError(t, preStore.PutHeight(2000))
+
+	// Second slasher starts up with an empty fresh ListEvidences result (since
+	// FP1 was filtered out by startHeight=2000+1 in the real chain) but should
+	// still query FP1's delegations because of the pending entry.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockBabylonQuerier := btcslasher.NewMockBabylonQueryClient(ctrl)
+	mockBTCClient := mocks.NewMockBTCClient(ctrl)
+	btccParams := &btcctypes.QueryParamsResponse{Params: btcctypes.Params{BtcConfirmationDepth: 10, CheckpointFinalizationTimeout: 100}}
+	mockBabylonQuerier.EXPECT().BTCCheckpointParams().Return(btccParams, nil).AnyTimes()
+	mockBabylonQuerier.EXPECT().ListEvidences(gomock.Any(), gomock.Any()).Return(
+		&ftypes.QueryListEvidencesResponse{
+			Evidences:  nil,
+			Pagination: &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+	mockBabylonQuerier.EXPECT().FinalityProviderDelegations(gomock.Eq(fp1BTCPK.MarshalHex()), gomock.Any()).Return(
+		&bstypes.QueryFinalityProviderDelegationsResponse{
+			BtcDelegatorDelegations: nil,
+			Pagination:              &query.PageResponse{NextKey: nil},
+		}, nil).Times(1)
+
+	bs, err := btcslasher.New(
+		logger, mockBTCClient, mockBabylonQuerier, net,
+		commonCfg.RetrySleepTime, commonCfg.MaxRetrySleepTime, commonCfg.MaxRetryTimes,
+		config.MaxSlashingConcurrency, make(chan *btcec.PrivateKey, 100),
+		metrics.NewBTCStakingTrackerMetrics().SlasherMetrics, 5*time.Second, db,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, bs.Bootstrap(2000))
+	bs.WaitForShutdown()
+
+	// Pending bucket should now be empty (FP1 was processed and the wrapper
+	// goroutine deleted it).
+	inspect, err := storepkg.NewSlasherStore(db)
+	require.NoError(t, err)
+	pending, err := inspect.ListPendingEvidences()
+	require.NoError(t, err)
+	require.Empty(t, pending)
 }

--- a/btcstaking-tracker/btcslasher/slasher.go
+++ b/btcstaking-tracker/btcslasher/slasher.go
@@ -196,9 +196,12 @@ func (bs *BTCSlasher) slashingEnforcer() {
 	}
 }
 
-// SlashFinalityProvider slashes all BTC delegations under a given finality provider
-// the checkBTC option indicates whether to check the slashing tx's input is still spendable
-// on Bitcoin (including mempool txs).
+// SlashFinalityProvider slashes all BTC delegations under a given finality provider.
+// It dispatches per-delegation goroutines and a wrapper goroutine that, once all
+// per-delegation goroutines reach a terminal state (BTC tx K-deep confirmed or
+// all paths non-slashable, or context canceled), deletes the matching pending
+// evidence entries from the kvdb. On graceful shutdown the entries are
+// intentionally left in place so the next Bootstrap replays them.
 func (bs *BTCSlasher) SlashFinalityProvider(extractedFpBTCSK *btcec.PrivateKey) error {
 	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(extractedFpBTCSK.PubKey())
 	bs.logger.Infof("start slashing finality provider %s", fpBTCPK.MarshalHex())
@@ -217,12 +220,18 @@ func (bs *BTCSlasher) SlashFinalityProvider(extractedFpBTCSK *btcec.PrivateKey) 
 	activeBTCDels = append(activeBTCDels, unbondedBTCDels...)
 	delegations := activeBTCDels
 
+	// per-FP WaitGroup; the wrapper goroutine below uses this to know when
+	// every delegation goroutine for this FP has finished retrying.
+	perFP := &sync.WaitGroup{}
+
 	// try to slash both staking and unbonding txs for each BTC delegation
 	// sign and submit slashing tx for each active and unbonded delegation
 	for _, del := range delegations {
 		bs.wg.Add(1)
+		perFP.Add(1)
 		go func(d *bstypes.BTCDelegationResponse) {
 			defer bs.wg.Done()
+			defer perFP.Done()
 			ctx, cancel := bs.quitContext()
 			defer cancel()
 
@@ -239,6 +248,37 @@ func (bs *BTCSlasher) SlashFinalityProvider(extractedFpBTCSK *btcec.PrivateKey) 
 	}
 
 	bs.metrics.SlashedFinalityProvidersCounter.Inc()
+
+	// Wrapper goroutine: once every per-delegation goroutine has finished, the
+	// pending entries for this FP can be removed. On graceful shutdown the
+	// entries are left in place so the next Bootstrap replays them.
+	bs.wg.Add(1)
+	go func() {
+		defer bs.wg.Done()
+		perFP.Wait()
+		select {
+		case <-bs.quit:
+			bs.logger.Debugf("slasher shutting down, leaving pending entries for fp %s for next bootstrap", fpBTCPK.MarshalHex())
+
+			return
+		default:
+		}
+		fpHex := fpBTCPK.MarshalHex()
+		pending, err := bs.store.ListPendingEvidences()
+		if err != nil {
+			bs.logger.Errorf("failed to list pending evidences while clearing fp %s: %v", fpHex, err)
+
+			return
+		}
+		for _, ev := range pending {
+			if ev.FpBtcPkHex != fpHex {
+				continue
+			}
+			if err := bs.store.DeletePendingEvidence(ev.BlockHeight, fpHex); err != nil {
+				bs.logger.Errorf("failed to delete pending evidence at height %d for fp %s: %v", ev.BlockHeight, fpHex, err)
+			}
+		}
+	}()
 
 	return nil
 }

--- a/btcstaking-tracker/btcslasher/store/store.go
+++ b/btcstaking-tracker/btcslasher/store/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 
+	ftypes "github.com/babylonlabs-io/babylon/v4/x/finality/types"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/lightningnetwork/lnd/kvdb"
 )
@@ -22,6 +23,8 @@ var (
 var (
 	processedEvidenceHeightBucket = []byte("processedevidenceheight")
 	processedEvidenceHeightKey    = []byte("lastevidenceheight")
+
+	pendingEvidencesBucket = []byte("pendingevidences")
 )
 
 func NewSlasherStore(backend kvdb.Backend) (*SlasherStore, error) {
@@ -35,8 +38,10 @@ func NewSlasherStore(backend kvdb.Backend) (*SlasherStore, error) {
 
 func (s *SlasherStore) createBucket() error {
 	if err := s.db.Update(func(tx kvdb.RwTx) error {
-		_, err := tx.CreateTopLevelBucket(processedEvidenceHeightBucket)
-		if err != nil {
+		if _, err := tx.CreateTopLevelBucket(processedEvidenceHeightBucket); err != nil {
+			return err
+		}
+		if _, err := tx.CreateTopLevelBucket(pendingEvidencesBucket); err != nil {
 			return err
 		}
 
@@ -89,6 +94,17 @@ func (s *SlasherStore) put(key []byte, val []byte, bucketName []byte) error {
 	})
 }
 
+func (s *SlasherStore) delete(key []byte, bucketName []byte) error {
+	return kvdb.Batch(s.db, func(tx kvdb.RwTx) error {
+		bucket := tx.ReadWriteBucket(bucketName)
+		if bucket == nil {
+			return ErrCorruptedDB
+		}
+
+		return bucket.Delete(key)
+	})
+}
+
 func (s *SlasherStore) LastProcessedHeight() (uint64, bool, error) {
 	data, f, err := s.get(processedEvidenceHeightKey, processedEvidenceHeightBucket)
 	if err != nil {
@@ -102,6 +118,68 @@ func (s *SlasherStore) LastProcessedHeight() (uint64, bool, error) {
 
 func (s *SlasherStore) PutHeight(height uint64) error {
 	return s.put(processedEvidenceHeightKey, uint64ToBytes(height), processedEvidenceHeightBucket)
+}
+
+// PutPendingEvidence persists an evidence that the slasher has dispatched but
+// has not yet confirmed durably-completed (i.e., BTC tx K-deep or all paths
+// non-slashable). Key is composed of big-endian block height followed by the
+// FP BTC PK hex bytes, so iteration is sorted by height.
+func (s *SlasherStore) PutPendingEvidence(ev *ftypes.EvidenceResponse) error {
+	if ev == nil {
+		return errors.New("nil evidence")
+	}
+	key := pendingEvidenceKey(ev.BlockHeight, ev.FpBtcPkHex)
+	val, err := ev.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return s.put(key, val, pendingEvidencesBucket)
+}
+
+// DeletePendingEvidence removes a pending evidence after all per-delegation
+// goroutines for that FP at that height have reached a terminal state.
+// Deleting a missing key is a no-op.
+func (s *SlasherStore) DeletePendingEvidence(blockHeight uint64, fpBtcPkHex string) error {
+	return s.delete(pendingEvidenceKey(blockHeight, fpBtcPkHex), pendingEvidencesBucket)
+}
+
+// ListPendingEvidences returns all pending evidences in ascending block-height
+// order (and lexicographic by fp pk within the same height).
+func (s *SlasherStore) ListPendingEvidences() ([]*ftypes.EvidenceResponse, error) {
+	var out []*ftypes.EvidenceResponse
+	err := s.db.View(func(tx walletdb.ReadTx) error {
+		b := tx.ReadBucket(pendingEvidencesBucket)
+		if b == nil {
+			return ErrCorruptedDB
+		}
+
+		return b.ForEach(func(_, v []byte) error {
+			var ev ftypes.EvidenceResponse
+			if err := ev.Unmarshal(v); err != nil {
+				return err
+			}
+			out = append(out, &ev)
+
+			return nil
+		})
+	}, func() {})
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func pendingEvidenceKey(blockHeight uint64, fpBtcPkHex string) []byte {
+	// 8 bytes BE height || fp pk hex bytes — BE ensures ascending iteration by height
+	key := make([]byte, 0, 8+len(fpBtcPkHex))
+	heightBE := make([]byte, 8)
+	binary.BigEndian.PutUint64(heightBE, blockHeight)
+	key = append(key, heightBE...)
+	key = append(key, []byte(fpBtcPkHex)...)
+
+	return key
 }
 
 func uint64ToBytes(n uint64) []byte {


### PR DESCRIPTION
## Summary

- Fixes a BTC-side slashing bypass triggered by a vigilante restart between slashing dispatch and BTC tx broadcast. The bootstrap cursor advanced on async dispatch, so on restart Babylon's `ListEvidences(startHeight)` would filter out an FP whose first slashable evidence sat below the persisted cursor, leaving it permanently un-slashed.
- Adds a persistent `pendingevidences` bucket to the slasher kvdb. New evidences are written before slashing dispatch, then deleted by a per-FP wrapper goroutine once every per-delegation goroutine reaches a terminal state (BTC tx K-deep or all paths non-slashable). On graceful shutdown the entries are intentionally left in place so the next Bootstrap replays them.
- On Bootstrap, pending entries are replayed before the cursor-based query. Bitcoin tx submission is already idempotent via `isTxSubmittedToBitcoin`, so replay is safe even when a tx was previously broadcast.