### PR TITLE
test(e2e): un-skip GHSA stake-expansion test by overriding babylond image to v4.3.0

### DIFF
--- a/e2etest/container/container.go
+++ b/e2etest/container/container.go
@@ -56,6 +56,13 @@ func NewManager(t *testing.T) (docker *Manager, err error) {
 	return docker, nil
 }
 
+// SetBabylonVersion overrides the babylond image tag for this manager. The
+// default is read from go.mod via NewImageConfig; tests that exercise
+// server-side behavior introduced after that version can opt into a newer tag.
+func (m *Manager) SetBabylonVersion(version string) {
+	m.cfg.BabylonVersion = version
+}
+
 func (m *Manager) ExecBitcoindCliCmd(t *testing.T, command []string) (bytes.Buffer, bytes.Buffer, error) {
 	// this is currently hardcoded, as it will be the same for all tests
 	cmd := []string{"bitcoin-cli", "-chain=regtest", "-rpcuser=user", "-rpcpassword=pass"}

--- a/e2etest/test_manager.go
+++ b/e2etest/test_manager.go
@@ -63,6 +63,9 @@ type TestManagerConfig struct {
 	NumMatureOutputsInWallet uint32
 	EpochInterval            uint
 	NumCovenants             uint
+	// BabylonVersion overrides the babylond docker image tag for this test.
+	// Empty means use the default derived from go.mod.
+	BabylonVersion string
 }
 
 func defaultTestManagerConfig() *TestManagerConfig {
@@ -88,6 +91,16 @@ func WithEpochInterval(interval uint) TestManagerOption {
 func WithNumCovenants(numCovenants uint) TestManagerOption {
 	return func(config *TestManagerConfig) {
 		config.NumCovenants = numCovenants
+	}
+}
+
+// WithBabylonVersion runs the babylond container at a specific image tag,
+// independent of the babylon Go module version pinned in go.mod. Use sparingly
+// — the protobuf wire format must remain compatible between the client (Go
+// module) and the server (image tag).
+func WithBabylonVersion(version string) TestManagerOption {
+	return func(config *TestManagerConfig) {
+		config.BabylonVersion = version
 	}
 }
 
@@ -130,6 +143,10 @@ func StartManager(t *testing.T, options ...TestManagerOption) *TestManager {
 	tmCfg := defaultTestManagerConfig()
 	for _, option := range options {
 		option(tmCfg)
+	}
+
+	if tmCfg.BabylonVersion != "" {
+		manager.SetBabylonVersion(tmCfg.BabylonVersion)
 	}
 
 	btcHandler := NewBitcoindHandler(t, manager)

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -929,18 +929,21 @@ func TestStakeExpansionFlow(t *testing.T) {
 // final require.Eventually block will time out, signaling that the babylon
 // image needs to be bumped.
 func TestStakeExpansionParentUnbondAtOneDeepWhenChildUnbondedEarly(t *testing.T) {
-	// The end-to-end assertion requires babylond to accept the parent's
-	// MsgBTCUndelegate at sub-k depth when the child stake-expansion is
-	// already unbonded — that server-side change ships in babylon v4.3+.
-	// The current go.mod pins babylon v4.2.x, so the parent never transitions
-	// to UNBONDED and the final require.Eventually times out. Re-enable once
-	// the dependency is bumped.
-	t.Skip("requires babylond >= v4.3 server-side fix (current dep is v4.2.x); re-enable after the babylon bump")
 	t.Parallel()
 	// segwit is activated at height 300. It's necessary for staking/slashing tx
 	numMatureOutputs := uint32(300)
 
-	tm := StartManager(t, WithNumMatureOutputs(numMatureOutputs), WithEpochInterval(defaultEpochInterval))
+	// The end-to-end assertion requires babylond to accept the parent's
+	// MsgBTCUndelegate at sub-k depth when the child stake-expansion is
+	// already unbonded — that server-side change ships in babylon v4.3+.
+	// go.mod still pins v4.2.x for the Go SDK; we only override the docker
+	// image tag so this test exercises the v4.3 server behavior. Drop the
+	// override once the babylon Go dep is bumped.
+	tm := StartManager(t,
+		WithNumMatureOutputs(numMatureOutputs),
+		WithEpochInterval(defaultEpochInterval),
+		WithBabylonVersion("v4.3.0"),
+	)
 	defer tm.Stop(t)
 	tm.CatchUpBTCLightClient(t)
 

--- a/e2etest/unbondingwatcher_e2e_test.go
+++ b/e2etest/unbondingwatcher_e2e_test.go
@@ -929,20 +929,22 @@ func TestStakeExpansionFlow(t *testing.T) {
 // final require.Eventually block will time out, signaling that the babylon
 // image needs to be bumped.
 func TestStakeExpansionParentUnbondAtOneDeepWhenChildUnbondedEarly(t *testing.T) {
+	// babylondGHSAFixVersion is the first babylond release containing the
+	// server-side fix that accepts MsgBTCUndelegate for the parent at sub-k
+	// depth when the child stake-expansion is already unbonded. go.mod still
+	// pins v4.2.x for the Go SDK; we only override the docker image tag so
+	// this test exercises the v4.3 server behavior. Drop the override once
+	// the babylon Go dep is bumped.
+	const babylondGHSAFixVersion = "v4.3.0"
+
 	t.Parallel()
 	// segwit is activated at height 300. It's necessary for staking/slashing tx
 	numMatureOutputs := uint32(300)
 
-	// The end-to-end assertion requires babylond to accept the parent's
-	// MsgBTCUndelegate at sub-k depth when the child stake-expansion is
-	// already unbonded — that server-side change ships in babylon v4.3+.
-	// go.mod still pins v4.2.x for the Go SDK; we only override the docker
-	// image tag so this test exercises the v4.3 server behavior. Drop the
-	// override once the babylon Go dep is bumped.
 	tm := StartManager(t,
 		WithNumMatureOutputs(numMatureOutputs),
 		WithEpochInterval(defaultEpochInterval),
-		WithBabylonVersion("v4.3.0"),
+		WithBabylonVersion(babylondGHSAFixVersion),
 	)
 	defer tm.Stop(t)
 	tm.CatchUpBTCLightClient(t)


### PR DESCRIPTION
## Summary

`TestStakeExpansionParentUnbondAtOneDeepWhenChildUnbondedEarly` was added in #545 with a `t.Skip` because the assertion requires server-side behavior shipped in babylon `v4.3+`, while `main`'s `go.mod` still pins `babylon/v4 v4.2.x`. Bumping the Go dep is a larger change with broader implications; this PR introduces a smaller surgical alternative that lets the test run today.

## Approach

Decouple the babylond docker image tag from the `go.mod` version on a per-test basis:

- `container.Manager.SetBabylonVersion(version string)` — public setter so the image tag can be swapped after `NewManager` reads the default from `go.mod` via `testutil.GetBabylonVersion`.
- `TestManagerConfig.BabylonVersion` field + `WithBabylonVersion(version string)` test option, applied in `StartManager` before `RunBabylondResource` fires.
- The GHSA test drops its `t.Skip` and instead passes `WithBabylonVersion("v4.3.0")`, so it exercises the v4.3 server behavior while the Go SDK stays at v4.2.x.

The protobuf wire format must remain compatible between client and server — that's why the option is opt-in, not a global flip. Other e2e tests are unaffected; they keep using the `go.mod`-derived default.

## Origin

Backport of the equivalent change made on `release/v0.24.x` (PR #546). Same patch, just adjusted to reference v4.2.x in the comment instead of v4.0.0.

## Test plan

- [x] `go build -tags e2e ./e2etest/...`
- [ ] CI integration-tests green — the test now runs to completion against the v4.3.0 image and validates the GHSA-wcr8-g34v-7565 fix end-to-end

## Follow-up

When `babylon/v4` is bumped to `v4.3.x` in `go.mod`, drop the `WithBabylonVersion` override in this test (the default will catch up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)