### PR TITLE
build(goreleaser): align with babylon's release config and produce static binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ main
 tmp/
 build/
 dist/
+
+# goreleaser local-build artifacts
+*-linux-musl-cross.tgz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,47 +1,96 @@
 version: 2
-
 project_name: vigilante
+
+env:
+  - CGO_ENABLED=1
+  - CGO_LDFLAGS=-L/lib
+
+before:
+  hooks:
+    - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.x86_64.a
+    - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.aarch64.a
+    - wget -nc https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+
+    - curl -LO https://babylonlabs-build-artifacts.s3.eu-central-1.amazonaws.com/musl-toolchain/x86_64-linux-musl-cross.tgz
+    - tar xf x86_64-linux-musl-cross.tgz
+    - mv -n -u x86_64-linux-musl-cross /opt/musl-cross-x86_64
+
+    - curl -LO https://babylonlabs-build-artifacts.s3.eu-central-1.amazonaws.com/musl-toolchain/aarch64-linux-musl-cross.tgz
+    - tar xf aarch64-linux-musl-cross.tgz
+    - mv -n -u aarch64-linux-musl-cross /opt/musl-cross-aarch64
 
 builds:
   - id: vigilante-linux-amd64
     main: ./cmd/vigilante/main.go
     binary: vigilante
+    builder: go
+    gobinary: "go"
     goos:
       - linux
     goarch:
       - amd64
     env:
-      - GO111MODULE=on
+      - CC=/opt/musl-cross-x86_64/bin/x86_64-linux-musl-gcc
+      - LD=/opt/musl-cross-x86_64/bin/x86_64-linux-musl-ld
     flags:
       - -mod=readonly
       - -trimpath
     ldflags:
+      - -X github.com/babylonlabs-io/vigilante/version.version={{ .Version }}
+      - -linkmode=external
       - -w -s
+      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
     tags:
       - netgo
       - osusergo
+      - muslc
 
-  - id: vigilante-darwin-arm64
+  - id: vigilante-linux-arm64
     main: ./cmd/vigilante/main.go
     binary: vigilante
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    builder: go
+    gobinary: "go"
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=/opt/musl-cross-aarch64/bin/aarch64-linux-musl-gcc
+      - LD=/opt/musl-cross-aarch64/bin/aarch64-linux-musl-ld
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/babylonlabs-io/vigilante/version.version={{ .Version }}
+      - -linkmode=external
+      - -w -s
+      - -extldflags "-Wl,-z,muldefs -static -z noexecstack"
+    tags:
+      - netgo
+      - osusergo
+      - muslc
+
+  - id: vigilante-darwin
+    main: ./cmd/vigilante/main.go
+    binary: vigilante
+    builder: go
+    gobinary: "go"
     goos:
       - darwin
     goarch:
       - arm64
+      - amd64
     env:
-      - GO111MODULE=on
-      - CGO_ENABLED=1
       - CC=oa64-clang
-      - CGO_LDFLAGS=-L/lib -Wl,-rpath,/lib
-    ldflags:
-      - -w -s
-      - -linkmode=external
+      - CGO_CFLAGS=-mmacosx-version-min=10.12
+      - CGO_LDFLAGS=-L/lib -mmacosx-version-min=10.12
     flags:
       - -mod=readonly
       - -trimpath
+    ldflags:
+      - -X github.com/babylonlabs-io/vigilante/version.version={{ .Version }}
+      - -linkmode=external
+      - -w -s
     tags:
       - netgo
       - ledger
@@ -51,29 +100,21 @@ archives:
   - id: zipped
     builds:
       - vigilante-linux-amd64
+      - vigilante-linux-arm64
+      - vigilante-darwin
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
+    wrap_in_directory: false
     files:
       - none*
   - id: binaries
     builds:
       - vigilante-linux-amd64
+      - vigilante-linux-arm64
+      - vigilante-darwin
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
-    files:
-      - none*
-  - id: zipped-arm64
-    builds:
-      - vigilante-darwin-arm64
-    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    format: tar.gz
-    files:
-      - none*
-  - id: binaries-arm64
-    builds:
-      - vigilante-darwin-arm64
-    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    format: binary
+    wrap_in_directory: false
     files:
       - none*
 
@@ -85,9 +126,15 @@ release:
   github:
     owner: babylonlabs-io
     name: vigilante
+  # If PRERELEASE env var is set to "true", mark as prerelease
+  # Otherwise auto-detect based on tag suffix (-rc, -beta, etc.)
+  prerelease: '{{ if eq .Env.PRERELEASE "true" }}true{{ else }}auto{{ end }}'
 
 # Docs: https://goreleaser.com/customization/changelog/
 changelog:
   disable: true
 
 dist: dist
+
+git:
+  prerelease_suffix: "-rc"


### PR DESCRIPTION
## Summary

Refactors `.goreleaser.yml` to mirror the structure used by [babylonlabs-io/babylon@v4.3.0](https://github.com/babylonlabs-io/babylon/blob/v4.3.0/.goreleaser.yml) (without the testnet variants), so vigilante releases ship the same shape babylond does. Layers cleanly on top of #549 — that PR fixed the CI workflow to actually run goreleaser-cross; this PR fixes the goreleaser config it's running.

## Concrete changes

- **Linux is now statically linked.** Both `linux-amd64` and `linux-arm64` build with musl-cross (downloaded from babylon's S3 artifact bucket via the top-level `before` hook) plus the `muslc` build tag and `-extldflags "-Wl,-z,muldefs -static -z noexecstack"`. **Verified by running the linux-amd64 binary in a clean `alpine:3.20` container — exit 0, no `libwasmvm.so` needed.** Operators no longer have to install wasmvm separately.
- **Added `linux-arm64` and `darwin-amd64`** — vigilante now ships the same four os/arch combinations babylond does.
- **Single `darwin` build entry** covering both `arm64` and `amd64` under one config (matches babylon, uses `oa64-clang` which the goreleaser-cross image wraps for both archs).
- **Embedded version in binary.** Added `-X github.com/babylonlabs-io/vigilante/version.version={{ .Version }}` to ldflags. `vigilante version` now prints the actual tag instead of the literal `main`.
- **Auto-prerelease detection** via `release.prerelease` / `git.prerelease_suffix: -rc`, plus a `PRERELEASE` env-var override.
- **Top-level `env` and `before` hooks** dedup the wasmvm + musl-cross download steps across all builds.
- **Two archive entries per platform** (raw binary + `tar.gz`) matching babylon's release layout, with `wrap_in_directory: false`.

## Local CI parity test

Ran exactly the way #549's workflow runs goreleaser (`goreleaser-cross:v1.27.0`, `COSMWASM_VERSION` from `go list -m github.com/CosmWasm/wasmvm/v2`, plus `--snapshot --skip=publish`):

```
COSMWASM_VERSION=v2.2.4
release succeeded after 3m54s
```

Output:

| Artifact | Size | Type |
|---|---|---|
| `vigilante-…-darwin-amd64` (+ tar.gz) | 42 MB tar | Mach-O x86_64, `NOUNDEFS` |
| `vigilante-…-darwin-arm64` (+ tar.gz) | 38 MB tar | Mach-O arm64, `NOUNDEFS` |
| `vigilante-…-linux-amd64` (+ tar.gz) | 42 MB tar | ELF64 x86-64, **statically linked** (musl) |
| `vigilante-…-linux-arm64` (+ tar.gz) | 37 MB tar | ELF64 aarch64, **statically linked** (musl) |
| `vigilante_<version>_checksums.txt` | sha256 of all 8 |

8 distributable artifacts + checksum file. Linux binary executes inside a stripped Alpine container with no wasmvm and no glibc.

## Also

`*-linux-musl-cross.tgz` added to `.gitignore` — the before-hook drops these two tarballs in the project root when running locally, and they're large enough that a stray `git add -A` would be unfortunate.

## Test plan

- [x] `goreleaser release --clean --snapshot --skip=publish` inside `goreleaser-cross:v1.27.0` succeeds end-to-end
- [x] linux-amd64 binary runs in a clean `alpine:3.20` container (no glibc, no wasmvm)
- [x] all 4 binaries report expected `file` output (statically linked / NOUNDEFS)
- [x] embedded version string visible via `vigilante version`
- [ ] CI green on real tag push (will be exercised when next tag lands; #549's `workflow_dispatch` makes it easy to re-run if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)