### PR TITLE
fix(reporter): keep checkpoint segments until Babylon accepts the proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+* [#551](https://github.com/babylonlabs-io/vigilante/pull/551) fix(reporter): keep checkpoint segments until Babylon accepts the proof
 * [#541](https://github.com/babylonlabs-io/vigilante/pull/541) fix: rehydrate submitter `lastSubmittedCheckpoint` from store on restart so the RBF path has valid Tx1/Tx2 info instead of panicking / looping on a nil Tx2
 * [#513](https://github.com/babylonlabs-io/vigilante/pull/513) fix: replace panic with error return for non-unbonding spending paths
 * [#549](https://github.com/babylonlabs-io/vigilante/pull/549) ci: fix goreleaser by running it inside `goreleaser-cross` so the darwin/arm64 pre-hook can write to `/lib` and use `oa64-clang`; add `workflow_dispatch` trigger to re-run releases for already-pushed tags and source the wasmvm version from `go.mod` instead of hardcoding it

--- a/e2etest/reporter_checkpoint_cache_poison_e2e_test.go
+++ b/e2etest/reporter_checkpoint_cache_poison_e2e_test.go
@@ -1,0 +1,242 @@
+//go:build e2e
+// +build e2e
+
+package e2etest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	txformat "github.com/babylonlabs-io/babylon/v4/btctxformatter"
+	checkpointingtypes "github.com/babylonlabs-io/babylon/v4/x/checkpointing/types"
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/vigilante/btcclient"
+	"github.com/babylonlabs-io/vigilante/metrics"
+	"github.com/babylonlabs-io/vigilante/netparams"
+	"github.com/babylonlabs-io/vigilante/reporter"
+)
+
+// VIG-02 e2e regression: covers the steady-state ordering case end-to-end
+// against a real bitcoind regtest, electrs, and babylond stack. The
+// attacker forges a part1 with the correct 10-byte checksum but a
+// corrupted BLS signature. The poisoned pair lands on Bitcoin first, the
+// reporter submits it, Babylon rejects it. With the fix in place the
+// reporter does NOT lose the legitimate part0: when the real part1 is
+// later mined, the legit pair matches and the checkpoint progresses to
+// Submitted. Without the fix the checkpoint would stay Sealed.
+
+func vig02e2eFakeSecondPart(t *testing.T, tag txformat.BabylonTag, firstPart, secondPart []byte) []byte {
+	t.Helper()
+
+	firstData, err := txformat.IsBabylonCheckpointData(tag, txformat.CurrentVersion, firstPart)
+	require.NoError(t, err)
+	secondData, err := txformat.IsBabylonCheckpointData(tag, txformat.CurrentVersion, secondPart)
+	require.NoError(t, err)
+
+	fakeData := append([]byte(nil), secondData.Data...)
+	fakeData[0] ^= 0x01
+
+	expectedChecksum := sha256.Sum256(firstData.Data)
+	checksumStart := len(fakeData) - 10
+	require.Equal(t, expectedChecksum[:10], fakeData[checksumStart:])
+
+	fakeSecondPart := make([]byte, 0, len(secondPart))
+	fakeSecondPart = append(fakeSecondPart, tag...)
+	fakeSecondPart = append(fakeSecondPart, byte(1<<4|txformat.CurrentVersion))
+	fakeSecondPart = append(fakeSecondPart, fakeData...)
+
+	_, err = txformat.IsBabylonCheckpointData(tag, txformat.CurrentVersion, fakeSecondPart)
+	require.NoError(t, err)
+
+	return fakeSecondPart
+}
+
+func vig02e2eWaitForSealedEpoch(t *testing.T, tm *TestManager) uint64 {
+	t.Helper()
+
+	var epoch uint64
+	require.Eventually(t, func() bool {
+		resp, err := tm.BabylonClient.LatestEpochFromStatus(checkpointingtypes.Sealed)
+		if err != nil {
+			return false
+		}
+		epoch = resp.RawCheckpoint.EpochNum
+
+		return true
+	}, eventuallyWaitTimeOut, eventuallyPollTime)
+
+	return epoch
+}
+
+func vig02e2eCheckpointStatus(t *testing.T, tm *TestManager, epoch uint64) checkpointingtypes.CheckpointStatus {
+	t.Helper()
+
+	resp, err := tm.BabylonClient.RawCheckpoint(epoch)
+	require.NoError(t, err)
+
+	return resp.RawCheckpoint.Status
+}
+
+func vig02e2eEncodedParts(t *testing.T, tm *TestManager, epoch uint64) ([]byte, []byte, []byte) {
+	t.Helper()
+
+	ckptResp, err := tm.BabylonClient.RawCheckpoint(epoch)
+	require.NoError(t, err)
+	require.Equal(t, checkpointingtypes.Sealed, ckptResp.RawCheckpoint.Status)
+
+	rawCheckpoint, err := ckptResp.RawCheckpoint.Ckpt.ToRawCheckpoint()
+	require.NoError(t, err)
+
+	submitterAddr, err := sdk.AccAddressFromBech32(tm.BabylonClient.MustGetAddr())
+	require.NoError(t, err)
+
+	btcCheckpoint, err := checkpointingtypes.FromRawCkptToBTCCkpt(rawCheckpoint, submitterAddr)
+	require.NoError(t, err)
+
+	btccParams, err := tm.BabylonClient.QueryClient.BTCCheckpointParams()
+	require.NoError(t, err)
+
+	tagBytes, err := hex.DecodeString(btccParams.Params.CheckpointTag)
+	require.NoError(t, err)
+	tag := txformat.BabylonTag(tagBytes)
+
+	firstPart, secondPart, err := txformat.EncodeCheckpointData(tag, txformat.CurrentVersion, btcCheckpoint)
+	require.NoError(t, err)
+
+	fakeSecondPart := vig02e2eFakeSecondPart(t, tag, firstPart, secondPart)
+
+	return firstPart, secondPart, fakeSecondPart
+}
+
+func vig02e2eSendOpReturnTx(t *testing.T, tm *TestManager, data []byte) *chainhash.Hash {
+	t.Helper()
+
+	tx := wire.NewMsgTx(wire.TxVersion)
+	dataScript, err := txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(data).Script()
+	require.NoError(t, err)
+	tx.AddTxOut(wire.NewTxOut(0, dataScript))
+
+	changePosition := 1
+	fundedTx, err := tm.BTCClient.FundRawTransaction(tx, btcjson.FundRawTransactionOpts{
+		ChangePosition: &changePosition,
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, tm.BTCClient.WalletPassphrase(tm.Config.BTC.WalletPassword, tm.Config.BTC.WalletLockTime))
+	signedTx, complete, err := tm.BTCClient.SignRawTransactionWithWallet(fundedTx.Transaction)
+	require.NoError(t, err)
+	require.True(t, complete)
+
+	hash, err := tm.BTCClient.SendRawTransaction(signedTx, true)
+	require.NoError(t, err)
+
+	return hash
+}
+
+func vig02e2eStartReporter(t *testing.T, tm *TestManager, m *metrics.ReporterMetrics) *reporter.Reporter {
+	t.Helper()
+
+	btcParams, err := netparams.GetBTCParams(tm.Config.BTC.NetParams)
+	require.NoError(t, err)
+	btcCfg := btcclient.ToBitcoindConfig(tm.Config.BTC)
+	btcNotifier, err := btcclient.NewNodeBackend(btcCfg, btcParams, &btcclient.EmptyHintCache{})
+	require.NoError(t, err)
+
+	r, err := reporter.New(
+		&tm.Config.Reporter,
+		logger,
+		tm.BTCClient,
+		tm.BabylonClient,
+		btcNotifier,
+		tm.Config.Common.RetrySleepTime,
+		tm.Config.Common.MaxRetrySleepTime,
+		tm.Config.Common.MaxRetryTimes,
+		m,
+	)
+	require.NoError(t, err)
+	r.Start()
+
+	return r
+}
+
+// TestReporter_CheckpointCachePoisoning_RecoversAfterRealPart1 reproduces
+// the VIG-02 attack ordering against the full local stack and asserts the
+// fixed behavior: the checkpoint reaches Submitted once the real part1
+// arrives, even after the poisoned proof was rejected by Babylon.
+func TestReporter_CheckpointCachePoisoning_RecoversAfterRealPart1(t *testing.T) {
+	t.Parallel()
+
+	// numMatureOutputs needs to be high enough that we can fund several
+	// OP_RETURN transactions on top of whatever the test stack consumes.
+	tm := StartManager(t, WithNumMatureOutputs(300), WithEpochInterval(5))
+	defer tm.Stop(t)
+
+	targetEpoch := vig02e2eWaitForSealedEpoch(t, tm)
+	firstPart, realSecondPart, fakeSecondPart := vig02e2eEncodedParts(t, tm, targetEpoch)
+
+	reporterMetrics := metrics.NewReporterMetrics()
+	vigilantReporter := vig02e2eStartReporter(t, tm, reporterMetrics)
+	defer func() {
+		vigilantReporter.Stop()
+		vigilantReporter.WaitForShutdown()
+	}()
+
+	require.Eventually(t, func() bool {
+		return tm.BabylonBTCChainMatchesBtc(t)
+	}, longEventuallyWaitTimeOut, eventuallyPollTime)
+
+	// Mine the poison block: legitimate part0 plus checksum-valid fake part1.
+	part0Hash := vig02e2eSendOpReturnTx(t, tm, firstPart)
+	fakePart1Hash := vig02e2eSendOpReturnTx(t, tm, fakeSecondPart)
+	poisonBlock := tm.mineBlock(t)
+	t.Logf("poison block mined: part0=%s fake_part1=%s txs=%d",
+		part0Hash, fakePart1Hash, len(poisonBlock.Transactions))
+
+	// The reporter should match the poison pair, submit it, and have the
+	// submission rejected by Babylon. FailedCheckpointsCounter increments.
+	require.Eventually(t, func() bool {
+		return promtestutil.ToFloat64(reporterMetrics.FailedCheckpointsCounter) >= 1
+	}, longEventuallyWaitTimeOut, eventuallyPollTime,
+		"reporter should record one failed submission for the poisoned pair")
+	require.Equal(t, checkpointingtypes.Sealed, vig02e2eCheckpointStatus(t, tm, targetEpoch))
+
+	// Mine the real part1 in a later block. With the VIG-02 fix in place,
+	// the cache still holds real_part0, the (real_part0, fake_part1) pair
+	// is blacklisted, and the new (real_part0, real_part1) pair matches.
+	realPart1Hash := vig02e2eSendOpReturnTx(t, tm, realSecondPart)
+	realBlock := tm.mineBlock(t)
+	t.Logf("real part1 block mined: real_part1=%s txs=%d",
+		realPart1Hash, len(realBlock.Transactions))
+
+	// The legitimate proof should be submitted, and Babylon should advance
+	// the checkpoint to Submitted.
+	require.Eventually(t, func() bool {
+		status := vig02e2eCheckpointStatus(t, tm, targetEpoch)
+
+		return status == checkpointingtypes.Submitted ||
+			status == checkpointingtypes.Confirmed ||
+			status == checkpointingtypes.Finalized
+	}, longEventuallyWaitTimeOut, eventuallyPollTime,
+		"checkpoint must progress past Sealed once the real part1 lands; the VIG-02 fix preserves real_part0 across the poisoned rejection")
+
+	// Sanity: at least one successful submission was recorded for the
+	// legitimate pair (the poisoned pair contributed only to the failed
+	// counter).
+	require.GreaterOrEqual(t, promtestutil.ToFloat64(reporterMetrics.SuccessfulCheckpointsCounter), float64(1))
+	require.GreaterOrEqual(t, promtestutil.ToFloat64(reporterMetrics.FailedCheckpointsCounter), float64(1))
+
+	// Give the reporter a brief moment to drain any further matches; the
+	// poisoned pair must NOT be resubmitted on subsequent Match() cycles.
+	time.Sleep(2 * time.Second)
+	require.LessOrEqual(t, promtestutil.ToFloat64(reporterMetrics.FailedCheckpointsCounter), float64(2),
+		"poisoned pair should be blacklisted, not resubmitted repeatedly")
+}

--- a/reporter/checkpoint_cache_poison_test.go
+++ b/reporter/checkpoint_cache_poison_test.go
@@ -1,0 +1,239 @@
+package reporter_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/v4/btctxformatter"
+	"github.com/babylonlabs-io/babylon/v4/client/babylonclient"
+	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
+	btcctypes "github.com/babylonlabs-io/babylon/v4/x/btccheckpoint/types"
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	vdatagen "github.com/babylonlabs-io/vigilante/testutil/datagen"
+	vtypes "github.com/babylonlabs-io/vigilante/types"
+)
+
+// VIG-02 reporter-level regression: a poisoned (real_part0, fake_part1)
+// pair gets submitted, Babylon rejects it, and a later block bringing the
+// real part1 must still produce a successful submission. The fix keeps the
+// segments in the cache after the rejection and blacklists only the
+// specific (part0, part1) pair, so real_part0 can re-pair with real_part1.
+
+func vig02PoisonRawCheckpoint(seed int64, epoch uint64) *btctxformatter.RawBtcCheckpoint {
+	r := rand.New(rand.NewSource(seed))
+
+	return &btctxformatter.RawBtcCheckpoint{
+		Epoch:            epoch,
+		BlockHash:        datagen.GenRandomByteArray(r, btctxformatter.BlockHashLength),
+		BitMap:           datagen.GenRandomByteArray(r, btctxformatter.BitMapLength),
+		SubmitterAddress: datagen.GenRandomByteArray(r, btctxformatter.AddressLength),
+		BlsSig:           datagen.GenRandomByteArray(r, btctxformatter.BlsSigLength),
+	}
+}
+
+func vig02PoisonFakeSecondHalf(t *testing.T, tag btctxformatter.BabylonTag, firstHalf, realSecondHalf []byte) []byte {
+	t.Helper()
+
+	firstData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, firstHalf)
+	require.NoError(t, err)
+	secondData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, realSecondHalf)
+	require.NoError(t, err)
+
+	fakeData := append([]byte(nil), secondData.Data...)
+	fakeData[0] ^= 0x01
+
+	expectedChecksum := sha256.Sum256(firstData.Data)
+	checksumStart := len(fakeData) - 10
+	require.Equal(t, expectedChecksum[:10], fakeData[checksumStart:])
+
+	fakeSecondHalf := make([]byte, 0, len(realSecondHalf))
+	fakeSecondHalf = append(fakeSecondHalf, tag...)
+	fakeSecondHalf = append(fakeSecondHalf, byte(1<<4|btctxformatter.CurrentVersion))
+	fakeSecondHalf = append(fakeSecondHalf, fakeData...)
+
+	_, err = btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, fakeSecondHalf)
+	require.NoError(t, err)
+
+	return fakeSecondHalf
+}
+
+func vig02OpReturnTx(t *testing.T, r *rand.Rand, checkpointPart []byte) *wire.MsgTx {
+	t.Helper()
+
+	tx := vdatagen.GenRandomTx(r)
+	script, err := txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(checkpointPart).Script()
+	require.NoError(t, err)
+	tx.TxOut[0] = wire.NewTxOut(0, script)
+
+	return tx
+}
+
+func vig02CalcMerkleRoot(txs []*wire.MsgTx) chainhash.Hash {
+	utilTxs := make([]*btcutil.Tx, 0, len(txs))
+	for _, tx := range txs {
+		utilTxs = append(utilTxs, btcutil.NewTx(tx))
+	}
+	tree := blockchain.BuildMerkleTreeStore(utilTxs, false)
+
+	return *tree[len(tree)-1]
+}
+
+func vig02IndexedBlockWithParts(t *testing.T, r *rand.Rand, height uint32, prevHash *chainhash.Hash, parts ...[]byte) (*vtypes.IndexedBlock, chainhash.Hash) {
+	t.Helper()
+
+	block, _ := vdatagen.GenRandomBlock(r, 0, prevHash)
+	txs := []*wire.MsgTx{block.Transactions[0]}
+	for _, p := range parts {
+		txs = append(txs, vig02OpReturnTx(t, r, p))
+	}
+	block.Transactions = txs
+	block.Header.MerkleRoot = vig02CalcMerkleRoot(txs)
+
+	indexed := vtypes.NewIndexedBlockFromMsgBlock(height, block)
+	hash := indexed.BlockHash()
+
+	return indexed, hash
+}
+
+func vig02DefaultTagAndParts(t *testing.T, epoch uint64) ([]byte, []byte, []byte) {
+	t.Helper()
+
+	tagBytes, err := hex.DecodeString(btcctypes.DefaultParams().CheckpointTag)
+	require.NoError(t, err)
+	tag := btctxformatter.BabylonTag(tagBytes)
+	rawCheckpoint := vig02PoisonRawCheckpoint(20260428, epoch)
+	firstHalf, realSecondHalf, err := btctxformatter.EncodeCheckpointData(tag, btctxformatter.CurrentVersion, rawCheckpoint)
+	require.NoError(t, err)
+	fakeSecondHalf := vig02PoisonFakeSecondHalf(t, tag, firstHalf, realSecondHalf)
+
+	return firstHalf, realSecondHalf, fakeSecondHalf
+}
+
+// TestReporter_ProcessCheckpoints_PoisonedPart1RecoversAfterRealPart1Arrives
+// covers the steady-state ordering case end-to-end through the reporter:
+//   - Block A contains real_part0 and fake_part1 (the attacker's poison block)
+//   - The reporter submits the matched pair, Babylon rejects it
+//   - Block B contains real_part1
+//   - The reporter must produce a second, successful submission of the
+//     legitimate checkpoint (this is what the fix guarantees)
+func TestReporter_ProcessCheckpoints_PoisonedPart1RecoversAfterRealPart1Arrives(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonClient, r := newMockReporter(t, ctrl)
+	firstHalf, realSecondHalf, fakeSecondHalf := vig02DefaultTagAndParts(t, 99)
+
+	rng := rand.New(rand.NewSource(99))
+	blockA, blockAHash := vig02IndexedBlockWithParts(t, rng, 100, nil, firstHalf, fakeSecondHalf)
+	blockB, _ := vig02IndexedBlockWithParts(t, rng, 101, &blockAHash, realSecondHalf)
+
+	// First call (Block A): Babylon rejects with invalid-BLS-style error.
+	// Second call (Block B): Babylon accepts the legitimate proof.
+	gomock.InOrder(
+		mockBabylonClient.EXPECT().ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("invalid BLS multi-sig: raw checkpoint is invalid")).
+			Times(1),
+		mockBabylonClient.EXPECT().ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).
+			Times(1),
+	)
+
+	// Block A: poison submission gets rejected; segments stay in cache.
+	numSegs, numMatched := r.ProcessCheckpoints("bbn1poison", []*vtypes.IndexedBlock{blockA})
+	require.Equal(t, 2, numSegs)
+	require.Equal(t, 1, numMatched, "poison pair is matched and submitted")
+
+	// Block B: real_part1 arrives. With the fix, real_part0 is still in
+	// the cache (Match() did not delete it), so the legit pair matches
+	// and the reporter submits a second time, successfully.
+	numSegs, numMatched = r.ProcessCheckpoints("bbn1poison", []*vtypes.IndexedBlock{blockB})
+	require.Equal(t, 1, numSegs)
+	require.Equal(t, 1, numMatched, "real pair is matched and submitted after rejection of the poisoned pair")
+}
+
+// TestReporter_ProcessCheckpoints_PoisonedPair_NotResubmittedOnSubsequentMatches
+// pins the dedup behavior: once a pair has been rejected by Babylon, the
+// reporter must not resubmit the same proof on the next ProcessCheckpoints
+// invocation.
+func TestReporter_ProcessCheckpoints_PoisonedPair_NotResubmittedOnSubsequentMatches(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonClient, r := newMockReporter(t, ctrl)
+	firstHalf, _, fakeSecondHalf := vig02DefaultTagAndParts(t, 100)
+
+	rng := rand.New(rand.NewSource(100))
+	blockA, _ := vig02IndexedBlockWithParts(t, rng, 200, nil, firstHalf, fakeSecondHalf)
+	emptyBlock, _ := vig02IndexedBlockWithParts(t, rng, 201, nil)
+
+	// Babylon must be called exactly once across both ProcessCheckpoints
+	// invocations: the second invocation finds the same pair but skips it
+	// because it was already attempted.
+	mockBabylonClient.EXPECT().
+		ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("invalid BLS multi-sig: raw checkpoint is invalid")).
+		Times(1)
+
+	_, numMatched := r.ProcessCheckpoints("bbn1poison", []*vtypes.IndexedBlock{blockA})
+	require.Equal(t, 1, numMatched)
+
+	// Subsequent processing must not resubmit the rejected pair. We pass
+	// an empty block to drive the matchAndSubmitCheckpoints path without
+	// adding new segments.
+	_, numMatched = r.ProcessCheckpoints("bbn1poison", []*vtypes.IndexedBlock{emptyBlock})
+	require.Equal(t, 0, numMatched, "blacklisted pair must not be re-submitted")
+}
+
+// TestReporter_ProcessCheckpoints_TransientErrorAllowsRetry pins the
+// transient-error branch: if ReliablySendMsg returns the broadcast-timeout
+// error, the segments stay in the cache without being marked attempted, so
+// the next ProcessCheckpoints call retries the same pair.
+func TestReporter_ProcessCheckpoints_TransientErrorAllowsRetry(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBabylonClient, r := newMockReporter(t, ctrl)
+	firstHalf, realSecondHalf, _ := vig02DefaultTagAndParts(t, 101)
+
+	rng := rand.New(rand.NewSource(101))
+	blockA, blockAHash := vig02IndexedBlockWithParts(t, rng, 300, nil, firstHalf, realSecondHalf)
+	emptyBlock, _ := vig02IndexedBlockWithParts(t, rng, 301, &blockAHash)
+
+	gomock.InOrder(
+		mockBabylonClient.EXPECT().
+			ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _, _, _ interface{}) (*babylonclient.RelayerTxResponse, error) {
+				return nil, babylonclient.ErrTimeoutAfterWaitingForTxBroadcast
+			}).
+			Times(1),
+		mockBabylonClient.EXPECT().
+			ReliablySendMsg(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&babylonclient.RelayerTxResponse{Code: 0}, nil).
+			Times(1),
+	)
+
+	_, numMatched := r.ProcessCheckpoints("bbn1retry", []*vtypes.IndexedBlock{blockA})
+	require.Equal(t, 1, numMatched)
+
+	// On the next match cycle the same pair must be retried because the
+	// previous failure was transient. We avoid adding new segments.
+	_, numMatched = r.ProcessCheckpoints("bbn1retry", []*vtypes.IndexedBlock{emptyBlock})
+	require.Equal(t, 1, numMatched, "transient errors should not blacklist the pair")
+}

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -320,6 +320,18 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 					tx1Block.Txs[ckpt.Segments[0].TxIdx].Hash().String(),
 					tx2Block.Txs[ckpt.Segments[1].TxIdx].Hash().String(),
 				).Inc()
+
+				// Transient broadcast timeout: leave segments in the cache
+				// without marking the pair as attempted, so the next Match()
+				// will retry the same pair.
+			} else {
+				// Non-transient rejection (e.g. invalid BLS multi-sig from a
+				// poisoned part1, or any other validation error). Keep the
+				// segments cached so the legitimate part1, when it arrives,
+				// can still pair with this part0 (VIG-02). But mark this
+				// specific (part0, part1) pair as attempted so subsequent
+				// Match() calls do not resubmit the same rejected proof.
+				r.checkpointCache.MarkAttempted(ckpt)
 			}
 
 			continue
@@ -333,6 +345,11 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer string) int {
 			r.logger.Infof("Successfully submitted checkpoint (MsgInsertBTCSpvProof) with response %d, for epoch %d, height %d",
 				res.Code, ckpt.Epoch, tx1Block.Height)
 		}
+
+		// Babylon accepted the proof (or returned an expected duplicate /
+		// already-finalized response). Drop the source segments from the
+		// cache so the pair is not re-matched on the next Match() cycle.
+		r.checkpointCache.RemoveSegments(ckpt)
 
 		// either way if we or some other reporter submitted the checkpoint, we want to update the metrics
 		r.metrics.SuccessfulCheckpointsCounter.Inc()

--- a/types/ckpt_cache.go
+++ b/types/ckpt_cache.go
@@ -22,6 +22,13 @@ type CheckpointCache struct {
 	// first key: index of the segment in the checkpoint (0 or 1)
 	// second key: hash of the OP_RETURN data in this ckpt segment
 	Segments map[uint8]map[string]*CkptSegment
+
+	// attemptedPairs tracks (hash(part0) | hash(part1)) keys for matched pairs
+	// that have already been submitted to Babylon and rejected with a
+	// non-transient error. Match() skips these so the same poisoned proof
+	// is not resubmitted on every cycle. Entries are pruned by the cleanup
+	// routine using the same TTL applied to segments.
+	attemptedPairs map[string]time.Time
 }
 
 func NewCheckpointCache(tag btctxformatter.BabylonTag, version btctxformatter.FormatVersion) *CheckpointCache {
@@ -31,10 +38,11 @@ func NewCheckpointCache(tag btctxformatter.BabylonTag, version btctxformatter.Fo
 	}
 
 	return &CheckpointCache{
-		Tag:         tag,
-		Version:     version,
-		Checkpoints: []*Ckpt{},
-		Segments:    segMap,
+		Tag:            tag,
+		Version:        version,
+		Checkpoints:    []*Ckpt{},
+		Segments:       segMap,
+		attemptedPairs: map[string]time.Time{},
 	}
 }
 
@@ -63,30 +71,50 @@ func (c *CheckpointCache) sortCheckpoints() {
 	})
 }
 
+// pairKey returns a stable key identifying the (part0, part1) pair by the
+// sha256 of each segment's OP_RETURN data. This matches the key shape used
+// for c.Segments so the same hash bytes are reused.
+func pairKey(seg0, seg1 *CkptSegment) string {
+	h0 := sha256.Sum256(seg0.Data)
+	h1 := sha256.Sum256(seg1.Data)
+
+	return string(h0[:]) + "|" + string(h1[:])
+}
+
 // TODO: generalise to NumExpectedProofs > 2
 // TODO: optimise the complexity by hashmap
+//
+// Match scans cached part0/part1 segments and queues every (part0, part1)
+// pair that connects and decodes into a valid raw checkpoint. Pairs that
+// were previously submitted and rejected with a non-transient error are
+// skipped via attemptedPairs. Segments are NOT deleted here, so the same
+// part0 can later pair with a different part1 if the first attempt is
+// rejected by Babylon (see VIG-02 fix).
 func (c *CheckpointCache) Match() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for hash1, ckptSeg1 := range c.Segments[uint8(0)] {
-		for hash2, ckptSeg2 := range c.Segments[uint8(1)] {
+	for _, ckptSeg1 := range c.Segments[uint8(0)] {
+		for _, ckptSeg2 := range c.Segments[uint8(1)] {
+			if _, ok := c.attemptedPairs[pairKey(ckptSeg1, ckptSeg2)]; ok {
+				// this pair was submitted before and rejected; skip it
+				// to avoid resubmitting the same proof
+				continue
+			}
 			connected, err := btctxformatter.ConnectParts(c.Version, ckptSeg1.Data, ckptSeg2.Data)
 			if err != nil {
 				continue
 			}
-			// found a pair, check if it is a validPop checkpoint
+			// found a pair, check if it is a valid checkpoint
 			rawCheckpoint, err := btctxformatter.DecodeRawCheckpoint(c.Version, connected)
 			if err != nil {
 				continue
 			}
-			// create the matched checkpoint
+			// queue the matched checkpoint candidate. Segments stay in the
+			// cache until submission succeeds (RemoveSegments) or the pair
+			// is rejected by Babylon (MarkAttempted).
 			ckpt := NewCkpt(ckptSeg1, ckptSeg2, rawCheckpoint.Epoch)
-			// add to the ckptList
 			c.AddCheckpoint(ckpt)
-			// remove the two ckptSeg in segMap
-			delete(c.Segments[uint8(0)], hash1)
-			delete(c.Segments[uint8(1)], hash2)
 		}
 	}
 
@@ -108,6 +136,39 @@ func (c *CheckpointCache) PopEarliestCheckpoint() *Ckpt {
 	return nil
 }
 
+// MarkAttempted records that the (part0, part1) pair backing the given
+// matched checkpoint was submitted to Babylon and rejected with a
+// non-transient error. Subsequent Match() calls will skip this pair so
+// the same poisoned proof is not resubmitted. Segments are intentionally
+// kept in the cache so part0 can still pair with a different part1
+// (e.g. the legitimate one) on a later Match() call.
+func (c *CheckpointCache) MarkAttempted(ckpt *Ckpt) {
+	if ckpt == nil || len(ckpt.Segments) != int(btctxformatter.NumberOfParts) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.attemptedPairs[pairKey(ckpt.Segments[0], ckpt.Segments[1])] = time.Now()
+}
+
+// RemoveSegments removes the segments composing the given matched checkpoint
+// from the cache. Called after the proof is accepted by Babylon (or returns
+// an expected duplicate/finalized response) so the pair is not re-matched
+// on the next Match() call. Also clears any attemptedPairs entry for the
+// pair, since the pair has now been resolved.
+func (c *CheckpointCache) RemoveSegments(ckpt *Ckpt) {
+	if ckpt == nil || len(ckpt.Segments) != int(btctxformatter.NumberOfParts) {
+		return
+	}
+	h0 := sha256.Sum256(ckpt.Segments[0].Data)
+	h1 := sha256.Sum256(ckpt.Segments[1].Data)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.Segments[uint8(0)], string(h0[:]))
+	delete(c.Segments[uint8(1)], string(h1[:]))
+	delete(c.attemptedPairs, string(h0[:])+"|"+string(h1[:]))
+}
+
 func (c *CheckpointCache) NumSegments() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -127,6 +188,16 @@ func (c *CheckpointCache) NumCheckpoints() int {
 	return len(c.Checkpoints)
 }
 
+// NumAttemptedPairs reports how many (part0, part1) pairs are currently
+// blacklisted from re-matching due to prior rejection by Babylon. Intended
+// for tests and observability.
+func (c *CheckpointCache) NumAttemptedPairs() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.attemptedPairs)
+}
+
 func (c *CheckpointCache) StartCleanupRoutine(stopChan chan struct{}, cleanupInterval time.Duration, segmentTTL time.Duration) {
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
@@ -142,6 +213,13 @@ func (c *CheckpointCache) StartCleanupRoutine(stopChan chan struct{}, cleanupInt
 					if now.Sub(seg.Timestamp) > segmentTTL {
 						delete(segMap, hash)
 					}
+				}
+			}
+			// prune attemptedPairs entries that have outlived the segment
+			// TTL so the set does not grow unbounded
+			for key, ts := range c.attemptedPairs {
+				if now.Sub(ts) > segmentTTL {
+					delete(c.attemptedPairs, key)
 				}
 			}
 			c.mu.Unlock()

--- a/types/ckpt_cache_poison_test.go
+++ b/types/ckpt_cache_poison_test.go
@@ -1,0 +1,259 @@
+package types_test
+
+import (
+	"crypto/sha256"
+	"math/rand"
+	"testing"
+
+	"github.com/babylonlabs-io/babylon/v4/btctxformatter"
+	"github.com/babylonlabs-io/babylon/v4/testutil/datagen"
+	"github.com/babylonlabs-io/vigilante/types"
+	"github.com/stretchr/testify/require"
+)
+
+// VIG-02 regression: an attacker who observes a legitimate part0 on Bitcoin
+// can forge a part1 with the correct 10-byte checksum but a corrupted BLS
+// signature. Before the fix, CheckpointCache.Match() paired real_part0 with
+// the fake part1 and immediately deleted both segments; the rejected proof
+// then orphaned the real part1 when it arrived later. After the fix, the
+// pair is queued without deletion, the rejected pair is recorded so it is
+// not retried, and a later real part1 can still match real_part0.
+
+func vig02RawCheckpoint(seed int64, epoch uint64) *btctxformatter.RawBtcCheckpoint {
+	r := rand.New(rand.NewSource(seed))
+
+	return &btctxformatter.RawBtcCheckpoint{
+		Epoch:            epoch,
+		BlockHash:        datagen.GenRandomByteArray(r, btctxformatter.BlockHashLength),
+		BitMap:           datagen.GenRandomByteArray(r, btctxformatter.BitMapLength),
+		SubmitterAddress: datagen.GenRandomByteArray(r, btctxformatter.AddressLength),
+		BlsSig:           datagen.GenRandomByteArray(r, btctxformatter.BlsSigLength),
+	}
+}
+
+func vig02SegmentsFromEncoded(t *testing.T, tag btctxformatter.BabylonTag, firstHalf, secondHalf []byte) (*types.CkptSegment, *types.CkptSegment) {
+	t.Helper()
+
+	firstData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, firstHalf)
+	require.NoError(t, err)
+	secondData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, secondHalf)
+	require.NoError(t, err)
+
+	return &types.CkptSegment{BabylonData: firstData}, &types.CkptSegment{BabylonData: secondData}
+}
+
+// vig02FakeSecondHalf builds a part1 OP_RETURN payload that keeps the
+// 10-byte checksum over the legitimate part0 but corrupts the BLS signature
+// bytes. ConnectParts and DecodeRawCheckpoint accept it locally; Babylon's
+// VerifyCheckpoint rejects it as "invalid BLS multi-sig".
+func vig02FakeSecondHalf(t *testing.T, tag btctxformatter.BabylonTag, firstHalf, realSecondHalf []byte) []byte {
+	t.Helper()
+
+	firstData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, firstHalf)
+	require.NoError(t, err)
+	secondData, err := btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, realSecondHalf)
+	require.NoError(t, err)
+
+	fakeData := append([]byte(nil), secondData.Data...)
+	fakeData[0] ^= 0x01
+
+	expectedChecksum := sha256.Sum256(firstData.Data)
+	checksumStart := len(fakeData) - 10
+	require.Equal(t, expectedChecksum[:10], fakeData[checksumStart:])
+
+	fakeSecondHalf := make([]byte, 0, len(realSecondHalf))
+	fakeSecondHalf = append(fakeSecondHalf, tag...)
+	fakeSecondHalf = append(fakeSecondHalf, byte(1<<4|btctxformatter.CurrentVersion))
+	fakeSecondHalf = append(fakeSecondHalf, fakeData...)
+
+	_, err = btctxformatter.IsBabylonCheckpointData(tag, btctxformatter.CurrentVersion, fakeSecondHalf)
+	require.NoError(t, err)
+
+	return fakeSecondHalf
+}
+
+// TestCheckpointCachePoisonedPart1DoesNotConsumeRealPart0 covers the
+// steady-state ordering case: the poison block (real_part0 + fake_part1)
+// is processed first, its proof is rejected by Babylon, and a later block
+// brings the real part1. The fix must keep real_part0 around so the
+// legitimate match still happens.
+func TestCheckpointCachePoisonedPart1DoesNotConsumeRealPart0(t *testing.T) {
+	t.Parallel()
+
+	tag := btctxformatter.BabylonTag([]byte("bbn0"))
+	rawCheckpoint := vig02RawCheckpoint(20260428, 88)
+	firstHalf, realSecondHalf, err := btctxformatter.EncodeCheckpointData(tag, btctxformatter.CurrentVersion, rawCheckpoint)
+	require.NoError(t, err)
+	fakeSecondHalf := vig02FakeSecondHalf(t, tag, firstHalf, realSecondHalf)
+
+	firstSeg, fakeSecondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, fakeSecondHalf)
+	_, realSecondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, realSecondHalf)
+
+	cache := types.NewCheckpointCache(tag, btctxformatter.CurrentVersion)
+	require.NoError(t, cache.AddSegment(firstSeg))
+	require.NoError(t, cache.AddSegment(fakeSecondSeg))
+
+	// First match: legit part0 + fake part1 connect locally.
+	cache.Match()
+	require.Equal(t, 1, cache.NumCheckpoints(), "the poisoned pair is queued for submission")
+	require.Equal(t, 2, cache.NumSegments(), "VIG-02 fix: segments are NOT deleted at match time")
+
+	// Reporter pops the candidate and submits to Babylon. Babylon rejects
+	// it with a non-transient error (invalid BLS). The reporter calls
+	// MarkAttempted to prevent resubmitting the same proof.
+	popped := cache.PopEarliestCheckpoint()
+	require.NotNil(t, popped)
+	require.Equal(t, rawCheckpoint.Epoch, popped.Epoch)
+	cache.MarkAttempted(popped)
+	require.Equal(t, 1, cache.NumAttemptedPairs())
+	require.Equal(t, 2, cache.NumSegments(), "segments survive the rejection")
+
+	// Real part1 arrives in a later block.
+	require.NoError(t, cache.AddSegment(realSecondSeg))
+
+	cache.Match()
+	require.Equal(t, 1, cache.NumCheckpoints(),
+		"VIG-02 fix: real part1 matches real part0 after the poisoned pair was rejected")
+	require.Equal(t, 3, cache.NumSegments(),
+		"all segments still present until the successful submission removes them")
+
+	popped = cache.PopEarliestCheckpoint()
+	require.NotNil(t, popped)
+	require.Equal(t, rawCheckpoint.Epoch, popped.Epoch)
+
+	// Babylon accepts the legitimate proof. The reporter calls
+	// RemoveSegments to drop both halves of the matched pair.
+	cache.RemoveSegments(popped)
+	require.Equal(t, 1, cache.NumSegments(),
+		"only the unrelated fake_part1 remains after the legit pair is removed")
+	require.Equal(t, 0, cache.NumCheckpoints())
+
+	// A subsequent Match() must not requeue the poisoned pair: real_part0
+	// has been removed, and the (real_part0, fake_part1) key is also gone
+	// because RemoveSegments cleared it.
+	cache.Match()
+	require.Equal(t, 0, cache.NumCheckpoints(),
+		"poisoned pair no longer matchable: real_part0 has been removed")
+}
+
+// TestCheckpointCacheMatchSkipsPreviouslyAttemptedPairs ensures that calling
+// Match() repeatedly does not re-queue a pair that was already submitted and
+// rejected. Without the dedup set, the poisoned pair would resurface on
+// every Match() cycle and spam Babylon with the same rejected proof.
+func TestCheckpointCacheMatchSkipsPreviouslyAttemptedPairs(t *testing.T) {
+	t.Parallel()
+
+	tag := btctxformatter.BabylonTag([]byte("bbn0"))
+	rawCheckpoint := vig02RawCheckpoint(20260428, 88)
+	firstHalf, realSecondHalf, err := btctxformatter.EncodeCheckpointData(tag, btctxformatter.CurrentVersion, rawCheckpoint)
+	require.NoError(t, err)
+	fakeSecondHalf := vig02FakeSecondHalf(t, tag, firstHalf, realSecondHalf)
+
+	firstSeg, fakeSecondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, fakeSecondHalf)
+
+	cache := types.NewCheckpointCache(tag, btctxformatter.CurrentVersion)
+	require.NoError(t, cache.AddSegment(firstSeg))
+	require.NoError(t, cache.AddSegment(fakeSecondSeg))
+
+	cache.Match()
+	require.Equal(t, 1, cache.NumCheckpoints())
+	popped := cache.PopEarliestCheckpoint()
+	cache.MarkAttempted(popped)
+
+	// Subsequent Match() runs must not re-queue the same poisoned pair.
+	for i := 0; i < 5; i++ {
+		cache.Match()
+		require.Equal(t, 0, cache.NumCheckpoints(),
+			"attempted pair stays blacklisted across repeated Match() calls")
+	}
+}
+
+// TestCheckpointCacheMatchesBothPairsWhenRealPart1IsAlreadyCached covers
+// the bootstrap recovery path: when the reporter restarts, both fake_part1
+// and real_part1 are extracted from the BTC cache before Match() runs.
+// Match() must produce both candidate checkpoints (poisoned + real) so the
+// reporter's submission loop can fail on the poisoned one and succeed on
+// the real one.
+func TestCheckpointCacheMatchesBothPairsWhenRealPart1IsAlreadyCached(t *testing.T) {
+	t.Parallel()
+
+	tag := btctxformatter.BabylonTag([]byte("bbn0"))
+	rawCheckpoint := vig02RawCheckpoint(20260428, 88)
+	firstHalf, realSecondHalf, err := btctxformatter.EncodeCheckpointData(tag, btctxformatter.CurrentVersion, rawCheckpoint)
+	require.NoError(t, err)
+	fakeSecondHalf := vig02FakeSecondHalf(t, tag, firstHalf, realSecondHalf)
+
+	firstSeg, fakeSecondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, fakeSecondHalf)
+	_, realSecondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, realSecondHalf)
+
+	cache := types.NewCheckpointCache(tag, btctxformatter.CurrentVersion)
+	require.NoError(t, cache.AddSegment(firstSeg))
+	require.NoError(t, cache.AddSegment(fakeSecondSeg))
+	require.NoError(t, cache.AddSegment(realSecondSeg))
+
+	cache.Match()
+	require.Equal(t, 2, cache.NumCheckpoints(),
+		"both (real_part0, fake_part1) and (real_part0, real_part1) match")
+
+	// Simulate the reporter's submission loop: pop both candidates,
+	// reject one (poisoned), accept the other (real).
+	var poisoned, legit *types.Ckpt
+	for i := 0; i < 2; i++ {
+		ckpt := cache.PopEarliestCheckpoint()
+		require.NotNil(t, ckpt)
+		// distinguish by which part1 segment is referenced
+		fakeHash := sha256.Sum256(fakeSecondSeg.Data)
+		realHash := sha256.Sum256(realSecondSeg.Data)
+		ckptPart1Hash := sha256.Sum256(ckpt.Segments[1].Data)
+		switch ckptPart1Hash {
+		case fakeHash:
+			poisoned = ckpt
+		case realHash:
+			legit = ckpt
+		}
+	}
+	require.NotNil(t, poisoned, "poisoned candidate should be queued")
+	require.NotNil(t, legit, "real candidate should be queued")
+
+	cache.MarkAttempted(poisoned)
+	cache.RemoveSegments(legit)
+
+	// fake_part1 stays cached (nothing removed it), but the poisoned pair
+	// is blacklisted. real_part0 and real_part1 are gone after success.
+	require.Equal(t, 1, cache.NumSegments())
+	require.Equal(t, 1, cache.NumAttemptedPairs())
+
+	cache.Match()
+	require.Equal(t, 0, cache.NumCheckpoints(),
+		"no pairs left to match: real halves removed, poisoned pair blacklisted")
+}
+
+// TestCheckpointCacheRemoveSegmentsClearsAttemptedPairsForSamePair documents
+// that successfully resolving a pair (e.g. via duplicate-submission accept)
+// also clears the attempted-pair entry, freeing memory.
+func TestCheckpointCacheRemoveSegmentsClearsAttemptedPairsForSamePair(t *testing.T) {
+	t.Parallel()
+
+	tag := btctxformatter.BabylonTag([]byte("bbn0"))
+	rawCheckpoint := vig02RawCheckpoint(1, 1)
+	firstHalf, secondHalf, err := btctxformatter.EncodeCheckpointData(tag, btctxformatter.CurrentVersion, rawCheckpoint)
+	require.NoError(t, err)
+
+	firstSeg, secondSeg := vig02SegmentsFromEncoded(t, tag, firstHalf, secondHalf)
+
+	cache := types.NewCheckpointCache(tag, btctxformatter.CurrentVersion)
+	require.NoError(t, cache.AddSegment(firstSeg))
+	require.NoError(t, cache.AddSegment(secondSeg))
+
+	cache.Match()
+	require.Equal(t, 1, cache.NumCheckpoints())
+	ckpt := cache.PopEarliestCheckpoint()
+
+	cache.MarkAttempted(ckpt)
+	require.Equal(t, 1, cache.NumAttemptedPairs())
+
+	cache.RemoveSegments(ckpt)
+	require.Equal(t, 0, cache.NumAttemptedPairs(),
+		"successful resolution clears the attempted-pair entry")
+	require.Equal(t, 0, cache.NumSegments())
+}

--- a/types/ckpt_cache_test.go
+++ b/types/ckpt_cache_test.go
@@ -96,7 +96,23 @@ func FuzzCheckpointCache(f *testing.F) {
 
 		ckptCache.Match()
 
+		// VIG-02: Match() no longer deletes segments. Segments persist
+		// until either RemoveSegments (success path) or the cleanup TTL
+		// fires. Every cached part0/part1 stays in the segment maps
+		// regardless of whether it was matched into a Ckpt candidate.
 		require.Equal(t, numMatchedPairs, ckptCache.NumCheckpoints())
+		require.Equal(t, numPairs*2, ckptCache.NumSegments())
+
+		// After draining matched checkpoints with RemoveSegments (the
+		// path the reporter takes on a successful submission), only the
+		// segments from non-matching pairs should remain.
+		for {
+			ckpt := ckptCache.PopEarliestCheckpoint()
+			if ckpt == nil {
+				break
+			}
+			ckptCache.RemoveSegments(ckpt)
+		}
 		require.Equal(t, (numPairs-numMatchedPairs)*2, ckptCache.NumSegments())
 
 		go ckptCache.StartCleanupRoutine(nil, time.Second, time.Second)


### PR DESCRIPTION
## Summary

 Previously `CheckpointCache.Match()` deleted both checkpoint segments as soon as a `part0`/`part1` pair connected and decoded locally, before Babylon validated the proof. An attacker who observes a legitimate `part0` on Bitcoin can forge a `part1` with the correct 10-byte checksum but a corrupted BLS signature, get it mined before the real `part1`, and cause the reporter to consume the real `part0` on a proof that Babylon rejects. The orphaned real `part1` can then never match.

## Fix

- `Match()` no longer deletes segments at match time. It queues candidate checkpoints and skips pairs already recorded in a new `attemptedPairs` set.
- Submission outcome now drives segment lifecycle in `matchAndSubmitCheckpoints`:
  - success / expected (`ErrDuplicatedSubmission`, `ErrEpochAlreadyFinalized`) → `RemoveSegments`
  - transient (`ErrTimeoutAfterWaitingForTxBroadcast`) → leave segments untouched for retry
  - other rejection (e.g. invalid BLS) → `MarkAttempted`, keeping `part0` cached so a later legitimate `part1` can still match, while blacklisting the rejected pair so the same proof isn't resubmitted
- Cleanup routine prunes `attemptedPairs` on the existing segment TTL.

## Tests

- `types/ckpt_cache_poison_test.go`: cache-level regression (steady-state ordering, dedup across repeated `Match()`, bootstrap recovery with both pairs queued, attempted-pair cleanup on success)
- `reporter/checkpoint_cache_poison_test.go`: reporter-level with mocked Babylon (poison recovery, dedup across invocations, transient-error retry)
- `e2etest/reporter_checkpoint_cache_poison_e2e_test.go`: full bitcoind/electrs/babylond stack; mines poison block, asserts Babylon rejects, mines real `part1`, asserts checkpoint advances past Sealed
- Updated `FuzzCheckpointCache` for the new no-delete-on-match contract

All touched-package tests pass; `go vet` and `golangci-lint` clean including `-tags=e2e`.

