### PR TITLE
fix(sew): no new comet block is not a non-monotonic error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+* [#553](https://github.com/babylonlabs-io/vigilante/pull/553) fix(sew): treat "tip has not advanced yet" as a quiet no-op instead of a non-monotonic error in the comet block fetcher — at short poll intervals it logged an error on nearly every poll between blocks
 * [#541](https://github.com/babylonlabs-io/vigilante/pull/541) fix: rehydrate submitter `lastSubmittedCheckpoint` from store on restart so the RBF path has valid Tx1/Tx2 info instead of panicking / looping on a nil Tx2
 * [#513](https://github.com/babylonlabs-io/vigilante/pull/513) fix: replace panic with error return for non-unbonding spending paths
 * [#549](https://github.com/babylonlabs-io/vigilante/pull/549) ci: fix goreleaser by running it inside `goreleaser-cross` so the darwin/arm64 pre-hook can write to `/lib` and use `oa64-clang`; add `workflow_dispatch` trigger to re-run releases for already-pushed tags and source the wasmvm version from `go.mod` instead of hardcoding it

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher.go
@@ -1034,6 +1034,14 @@ func (sew *StakingEventWatcher) fetchCometBftBlockOnce() error {
 
 	currentHeight := sew.currentCometTipHeight.Load()
 
+	// currentCometTipHeight is the next height to process (last processed + 1),
+	// so a tip exactly one below it means no new block has been produced yet.
+	if latestHeight == currentHeight-1 {
+		sew.logger.Debugf("no new comet bft blocks, next height to process: %d", currentHeight)
+
+		return nil
+	}
+
 	// Enforce monotonic block height processing
 	if latestHeight < currentHeight {
 		return fmt.Errorf("non-monotonic block height detected: latest height %d is less than current height %d",

--- a/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
+++ b/btcstaking-tracker/stakingeventwatcher/stakingeventwatcher_test.go
@@ -693,3 +693,29 @@ func TestHandleSpend_StkExpUnbondedChildSkipsKDeepWait(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchCometBftBlockOnceNoNewBlock(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := config.DefaultBTCStakingTrackerConfig()
+	mockBabylonNodeAdapter := NewMockBabylonNodeAdapter(ctrl)
+
+	sew := StakingEventWatcher{
+		logger:             zap.NewNop().Sugar(),
+		cfg:                &cfg,
+		babylonNodeAdapter: mockBabylonNodeAdapter,
+	}
+
+	// block 100 was processed, so 101 is the next height to process
+	sew.currentCometTipHeight.Store(101)
+
+	// tip still at 100 -> no new block yet, must be a quiet no-op
+	mockBabylonNodeAdapter.EXPECT().CometBFTTipHeight(gomock.Any()).Return(int64(100), nil).Times(1)
+	require.NoError(t, sew.fetchCometBftBlockOnce())
+
+	// tip at 99 -> genuine regression below the processed height, must error
+	mockBabylonNodeAdapter.EXPECT().CometBFTTipHeight(gomock.Any()).Return(int64(99), nil).Times(1)
+	require.ErrorContains(t, sew.fetchCometBftBlockOnce(), "non-monotonic block height")
+}


### PR DESCRIPTION
## Problem

`fetchCometBftBlockOnce` stores `currentCometTipHeight = latestHeight + 1` — the **next height to process** — but the monotonicity guard compares the fresh tip against that next-expected value. So whenever the chain simply hasn't produced a block since the last poll (`latest == current - 1`), the guard fires:

```
error fetching comet bft block: non-monotonic block height detected: latest height 2772566 is less than current height 2772567
```

With `FetchCometBlockInterval` shorter than the block time this happens on nearly every poll. On Babylon testnet (2s polls, ~10s blocks) the bstracker logs ~12 of these per minute, ~700/hour, continuously — heights always exactly 1 apart, in bursts between blocks. Real error conditions get buried in the noise.

## Fix

Treat `latest == current - 1` as the quiet no-op it is (mirroring the existing `latest == current` no-new-blocks branch). A tip **below the last processed height** (`latest < current - 1`) still returns the non-monotonic error.

## Testing

Added `TestFetchCometBftBlockOnceNoNewBlock`: tip at `current-1` → no error; tip at `current-2` → non-monotonic error. Verified `go build` + the new test green; observed on testnet that every logged occurrence of this error over 24h was the `latest == current-1` case.